### PR TITLE
feat: Implement an initial naive reward amount targeting 7.9% annual.

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -3,6 +3,8 @@
 // runtime construction via `frame_support::runtime` does a lot of recursion and requires us to increase the limit.
 #![recursion_limit = "512"]
 
+mod tests;
+
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
@@ -162,7 +164,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 225,
+    spec_version: 226,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,
@@ -464,7 +466,7 @@ impl pallet_staking::EraPayout<Balance> for EraPayout {
 }
 
 parameter_types! {
-    // Six sessions in an era (24 hours).
+    // Twenty-Four sessions in an era (24 hours).
     pub const SessionsPerEra: SessionIndex = 24;
 
     // 7 eras for unbonding (7 days).

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -60,6 +60,7 @@ use sp_runtime::traits::{
     One,
     OpaqueKeys,
     Verify,
+    Zero,
 };
 use sp_runtime::transaction_validity::{
     TransactionPriority,
@@ -444,8 +445,8 @@ impl pallet_babe::Config for Runtime {
 pub struct EraPayout;
 impl pallet_staking::EraPayout<Balance> for EraPayout {
     fn era_payout(
-        _total_staked: Balance,
-        _total_issuance: Balance,
+        total_staked: Balance,
+        total_issuance: Balance,
         era_duration_millis: u64,
     ) -> (Balance, Balance) {
         const MILLISECONDS_PER_YEAR: u64 = (1000 * 3600 * 24 * 36525) / 100;
@@ -453,20 +454,12 @@ impl pallet_staking::EraPayout<Balance> for EraPayout {
         let relative_era_len =
             FixedU128::from_rational(era_duration_millis.into(), MILLISECONDS_PER_YEAR.into());
 
-        // TI at the time of execution of [Referendum 1139](https://polkadot.subsquare.io/referenda/1139), block hash: `0x39422610299a75ef69860417f4d0e1d94e77699f45005645ffc5e8e619950f9f`.
-        let fixed_total_issuance: i128 = 15_011_657_390_566_252_333;
-        let fixed_inflation_rate = FixedU128::from_rational(8, 100);
-        let yearly_emission = fixed_inflation_rate.saturating_mul_int(fixed_total_issuance);
+        let base_rate = FixedU128::from_rational(79, 1000);
+        let yearly_emission = base_rate.saturating_mul_int(total_staked);
 
         let era_emission = relative_era_len.saturating_mul_int(yearly_emission);
-        // 15% to treasury, as per ref 1139.
-        let to_treasury = FixedU128::from_rational(15, 100).saturating_mul_int(era_emission);
-        let to_stakers = era_emission.saturating_sub(to_treasury);
 
-        (
-            to_stakers.unique_saturated_into(),
-            to_treasury.unique_saturated_into(),
-        )
+        (era_emission.unique_saturated_into(), Balance::zero())
     }
 }
 

--- a/runtime/src/tests.rs
+++ b/runtime/src/tests.rs
@@ -1,0 +1,30 @@
+use pallet_staking::EraPayout;
+use sp_runtime::traits::Zero;
+
+use crate::{
+    Balance,
+    EraPayout as SXTPayout,
+    SessionsPerEra,
+    DOLLARS,
+    EPOCH_DURATION_IN_BLOCKS,
+    MILLISECS_PER_BLOCK,
+};
+
+#[test]
+fn era_payout_calculation_works() {
+    let test_staked: Balance = Balance::from(100 * DOLLARS);
+    let test_issued: Balance = Balance::from(1000 * DOLLARS);
+
+    // Test one session in an era
+    const MILLISECONDS_PER_YEAR: u64 = (1000 * 3600 * 24 * 36525) / 100;
+
+    // One day of Milliseconds
+    let test_ms_per_era = 1000 * 3600 * 24;
+
+    let (to_stakers, to_treasury) =
+        SXTPayout::era_payout(test_staked, test_issued, test_ms_per_era);
+    assert_eq!(to_treasury, Balance::zero());
+
+    let single_era_payout = Balance::from(21629021218343597u128);
+    assert_eq!(to_stakers, single_era_payout);
+}


### PR DESCRIPTION
# Rationale for this change
This update implements a relatively simple rewards distribution as a placeholder until additional tests are written to validate reward calculations in a fully active chain.