### PR TITLE
ci: fix check for ubuntu runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - if: contains(matrix.os, 'ubuntu')
+      - if: ${{ !contains(matrix.os, 'macos') }}
         uses: ./.github/actions/free-disk-space
-      - if: contains(matrix.os, 'ubuntu')
+      - if: ${{ !contains(matrix.os, 'macos') }}
         uses: ./.github/actions/ubuntu-dependencies
       - if: contains(matrix.os, 'macos')
         uses: ./.github/actions/macos-dependencies
-       
+
       - name: Run fmt
         run: cargo fmt --all --check -- --config imports_granularity=Module,group_imports=StdExternalCrate,imports_layout=HorizontalVertical
         timeout-minutes: 30
@@ -73,9 +73,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - if: contains(matrix.os, 'ubuntu')
+      - if: ${{ !contains(matrix.os, 'macos') }}
         uses: ./.github/actions/free-disk-space
-      - if: contains(matrix.os, 'ubuntu')
+      - if: ${{ !contains(matrix.os, 'macos') }}
         uses: ./.github/actions/ubuntu-dependencies
       - if: contains(matrix.os, 'macos')
         uses: ./.github/actions/macos-dependencies
@@ -85,7 +85,7 @@ jobs:
         with:
           name: sxt-node-binary-${{ matrix.os }}-${{ github.run_id }}
           path: ./target/release/
-        
+
       - name: Set executable permissions on the binary
         run: chmod +x ./target/release/sxt-node
 


### PR DESCRIPTION
We had recently changed the type of ubuntu runner to be one available to public repositories, which caused the dependencies to not be installed, and broke some clippy checks.

Rather than setting it to something like 22-04, we flipped the conditional to not be macos.

