### PR TITLE
ci: SDO-177 update publish workflow to have SRC_IMAGE_NAME and PUB_IMAGE_NAME

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,12 +22,14 @@ jobs:
   build_node:
     uses: ./.github/workflows/publish_shared.yml
     with:
-      IMAGE_NAME: sxt-node
+      SRC_IMAGE_NAME: sxtnode-docker-local/sxt-node
+      PUB_IMAGE_NAME: sxt-node
       working-directory: publish/docker/sxt-node
     secrets: inherit
   build_attestor:
     uses: ./.github/workflows/publish_shared.yml
     with:
-      IMAGE_NAME: sxt-attestor
+      SRC_IMAGE_NAME: sxt-node/watcher
+      PUB_IMAGE_NAME: sxt-attestor
       working-directory: publish/docker/sxt-attestor
     secrets: inherit

--- a/.github/workflows/publish_shared.yml
+++ b/.github/workflows/publish_shared.yml
@@ -4,7 +4,10 @@ on:
       working-directory:
         required: true
         type: string
-      IMAGE_NAME:
+      SRC_IMAGE_NAME:
+        required: true
+        type: string
+      PUB_IMAGE_NAME:
         required: true
         type: string
     secrets:
@@ -20,7 +23,6 @@ jobs:
     name: Build Image
     runs-on: ubuntu-latest
     env:
-      SRC_REPO: spaceandtime.jfrog.io/sxtnode-docker-local
       PUB_REPO: ghcr.io/spaceandtimefdn
 
     steps:
@@ -41,7 +43,7 @@ jobs:
           oidc-audience: ${{ secrets.OIDC_AUDIENCE }}
       - name: docker pull from jfrog
         run: |
-          jf docker pull ${{ env.SRC_REPO }}/${{ inputs.IMAGE_NAME }}:${{ env.GIT_REVISION }}
+          jf docker pull ${{ secrets.REGISTRY_URL }}/${{ inputs.SRC_IMAGE_NAME }}:${{ env.GIT_REVISION }}
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
@@ -54,7 +56,7 @@ jobs:
         with:
           context: ${{ inputs.working-directory }}
           push: true
-          tags: ${{ env.PUB_REPO }}/${{ inputs.IMAGE_NAME }}:${{ env.DOCKER_TAG }}
+          tags: ${{ env.PUB_REPO }}/${{ inputs.PUB_IMAGE_NAME }}:${{ env.DOCKER_TAG }}
           labels: ${{ env.DOCKER_TAG }}
           build-args: |
             GIT_REVISION=${{ env.GIT_REVISION }}


### PR DESCRIPTION
There are two reasons for this:
* the watcher will be called sxt-attestor publicly
* the watcher is in a different repository in jfrog compared to sxt-node
