### PR TITLE
feat: add proof plan RPCs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9994,6 +9994,7 @@ dependencies = [
  "proof-of-sql-commitment-map",
  "proof-of-sql-static-setups",
  "scale-info",
+ "sp-api",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -18714,6 +18715,7 @@ dependencies = [
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-utility",
  "parity-scale-codec",
+ "proof-of-sql-commitment-map",
  "scale-info",
  "sp-api",
  "sp-arithmetic",
@@ -18735,6 +18737,7 @@ dependencies = [
  "sp-transaction-pool",
  "sp-version",
  "substrate-wasm-builder",
+ "sxt-core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1515,6 +1515,27 @@ dependencies = [
 
 [[package]]
 name = "arrow"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219d05930b81663fd3b32e3bde8ce5bff3c4d23052a99f11a8fa50a3b47b2658"
+dependencies = [
+ "arrow-arith 51.0.0",
+ "arrow-array 51.0.0",
+ "arrow-buffer 51.0.0",
+ "arrow-cast 51.0.0",
+ "arrow-csv 51.0.0",
+ "arrow-data 51.0.0",
+ "arrow-ipc 51.0.0",
+ "arrow-json 51.0.0",
+ "arrow-ord 51.0.0",
+ "arrow-row 51.0.0",
+ "arrow-schema 51.0.0",
+ "arrow-select 51.0.0",
+ "arrow-string 51.0.0",
+]
+
+[[package]]
+name = "arrow"
 version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaf3437355979f1e93ba84ba108c38be5767713051f3c8ffbf07c094e2e61f9f"
@@ -1523,10 +1544,10 @@ dependencies = [
  "arrow-array 53.4.0",
  "arrow-buffer 53.4.0",
  "arrow-cast 53.4.0",
- "arrow-csv",
+ "arrow-csv 53.4.0",
  "arrow-data 53.4.0",
  "arrow-ipc 53.4.0",
- "arrow-json",
+ "arrow-json 53.4.0",
  "arrow-ord 53.4.0",
  "arrow-row 53.4.0",
  "arrow-schema 53.4.0",
@@ -1555,6 +1576,21 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0272150200c07a86a390be651abdd320a2d12e84535f0837566ca87ecd8f95e0"
+dependencies = [
+ "arrow-array 51.0.0",
+ "arrow-buffer 51.0.0",
+ "arrow-data 51.0.0",
+ "arrow-schema 51.0.0",
+ "chrono",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-arith"
 version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31dce77d2985522288edae7206bffd5fc4996491841dda01a13a58415867e681"
@@ -1579,6 +1615,23 @@ dependencies = [
  "arrow-data 54.2.1",
  "arrow-schema 54.2.1",
  "chrono",
+ "num",
+]
+
+[[package]]
+name = "arrow-array"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8010572cf8c745e242d1b632bd97bd6d4f40fefed5ed1290a8f433abaa686fea"
+dependencies = [
+ "ahash 0.8.11",
+ "arrow-buffer 51.0.0",
+ "arrow-data 51.0.0",
+ "arrow-schema 51.0.0",
+ "chrono",
+ "chrono-tz",
+ "half",
+ "hashbrown 0.14.5",
  "num",
 ]
 
@@ -1616,6 +1669,17 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d0a2432f0cba5692bf4cb757469c66791394bac9ec7ce63c1afe74744c37b27"
+dependencies = [
+ "bytes",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-buffer"
 version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b02656a35cc103f28084bc80a0159668e0a680d919cef127bd7e0aaccb06ec1"
@@ -1638,6 +1702,27 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9abc10cd7995e83505cc290df9384d6e5412b207b79ce6bdff89a10505ed2cba"
+dependencies = [
+ "arrow-array 51.0.0",
+ "arrow-buffer 51.0.0",
+ "arrow-data 51.0.0",
+ "arrow-schema 51.0.0",
+ "arrow-select 51.0.0",
+ "atoi",
+ "base64 0.22.1",
+ "chrono",
+ "comfy-table",
+ "half",
+ "lexical-core 0.8.5",
+ "num",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-cast"
 version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c73c6233c5b5d635a56f6010e6eb1ab9e30e94707db21cea03da317f67d84cf3"
@@ -1651,7 +1736,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "half",
- "lexical-core",
+ "lexical-core 1.0.5",
  "num",
  "ryu",
 ]
@@ -1672,9 +1757,28 @@ dependencies = [
  "chrono",
  "comfy-table",
  "half",
- "lexical-core",
+ "lexical-core 1.0.5",
  "num",
  "ryu",
+]
+
+[[package]]
+name = "arrow-csv"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95cbcba196b862270bf2a5edb75927380a7f3a163622c61d40cbba416a6305f2"
+dependencies = [
+ "arrow-array 51.0.0",
+ "arrow-buffer 51.0.0",
+ "arrow-cast 51.0.0",
+ "arrow-data 51.0.0",
+ "arrow-schema 51.0.0",
+ "chrono",
+ "csv",
+ "csv-core",
+ "lazy_static",
+ "lexical-core 0.8.5",
+ "regex",
 ]
 
 [[package]]
@@ -1692,8 +1796,20 @@ dependencies = [
  "csv",
  "csv-core",
  "lazy_static",
- "lexical-core",
+ "lexical-core 1.0.5",
  "regex",
+]
+
+[[package]]
+name = "arrow-data"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2742ac1f6650696ab08c88f6dd3f0eb68ce10f8c253958a18c943a68cd04aec5"
+dependencies = [
+ "arrow-buffer 51.0.0",
+ "arrow-schema 51.0.0",
+ "half",
+ "num",
 ]
 
 [[package]]
@@ -1749,6 +1865,21 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a42ea853130f7e78b9b9d178cb4cd01dee0f78e64d96c2949dc0a915d6d9e19d"
+dependencies = [
+ "arrow-array 51.0.0",
+ "arrow-buffer 51.0.0",
+ "arrow-cast 51.0.0",
+ "arrow-data 51.0.0",
+ "arrow-schema 51.0.0",
+ "flatbuffers 23.5.26",
+ "lz4_flex",
+]
+
+[[package]]
+name = "arrow-ipc"
 version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0270dc511f11bb5fa98a25020ad51a99ca5b08d8a8dfbd17503bb9dba0388f0b"
@@ -1758,7 +1889,7 @@ dependencies = [
  "arrow-cast 53.4.0",
  "arrow-data 53.4.0",
  "arrow-schema 53.4.0",
- "flatbuffers",
+ "flatbuffers 24.12.23",
 ]
 
 [[package]]
@@ -1771,7 +1902,27 @@ dependencies = [
  "arrow-buffer 54.2.1",
  "arrow-data 54.2.1",
  "arrow-schema 54.2.1",
- "flatbuffers",
+ "flatbuffers 24.12.23",
+]
+
+[[package]]
+name = "arrow-json"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaafb5714d4e59feae964714d724f880511500e3569cc2a94d02456b403a2a49"
+dependencies = [
+ "arrow-array 51.0.0",
+ "arrow-buffer 51.0.0",
+ "arrow-cast 51.0.0",
+ "arrow-data 51.0.0",
+ "arrow-schema 51.0.0",
+ "chrono",
+ "half",
+ "indexmap 2.8.0",
+ "lexical-core 0.8.5",
+ "num",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1788,10 +1939,25 @@ dependencies = [
  "chrono",
  "half",
  "indexmap 2.8.0",
- "lexical-core",
+ "lexical-core 1.0.5",
  "num",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e6b61e3dc468f503181dccc2fc705bdcc5f2f146755fa5b56d0a6c5943f412"
+dependencies = [
+ "arrow-array 51.0.0",
+ "arrow-buffer 51.0.0",
+ "arrow-data 51.0.0",
+ "arrow-schema 51.0.0",
+ "arrow-select 51.0.0",
+ "half",
+ "num",
 ]
 
 [[package]]
@@ -1824,6 +1990,21 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "848ee52bb92eb459b811fb471175ea3afcf620157674c8794f539838920f9228"
+dependencies = [
+ "ahash 0.8.11",
+ "arrow-array 51.0.0",
+ "arrow-buffer 51.0.0",
+ "arrow-data 51.0.0",
+ "arrow-schema 51.0.0",
+ "half",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "arrow-row"
 version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f936954991c360ba762dff23f5dda16300774fafd722353d9683abd97630ae"
@@ -1851,6 +2032,12 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d9483aaabe910c4781153ae1b6ae0393f72d9ef757d38d09d450070cf2e528"
+
+[[package]]
+name = "arrow-schema"
 version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9579b9d8bce47aa41389fe344f2c6758279983b7c0ebb4013e283e3e91bb450e"
@@ -1860,6 +2047,20 @@ name = "arrow-schema"
 version = "54.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85934a9d0261e0fa5d4e2a5295107d743b543a6e0484a835d4b8db2da15306f9"
+
+[[package]]
+name = "arrow-select"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "849524fa70e0e3c5ab58394c770cb8f514d0122d20de08475f7b472ed8075830"
+dependencies = [
+ "ahash 0.8.11",
+ "arrow-array 51.0.0",
+ "arrow-buffer 51.0.0",
+ "arrow-data 51.0.0",
+ "arrow-schema 51.0.0",
+ "num",
+]
 
 [[package]]
 name = "arrow-select"
@@ -1887,6 +2088,23 @@ dependencies = [
  "arrow-data 54.2.1",
  "arrow-schema 54.2.1",
  "num",
+]
+
+[[package]]
+name = "arrow-string"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9373cb5a021aee58863498c37eb484998ef13377f69989c6c5ccfbd258236cdb"
+dependencies = [
+ "arrow-array 51.0.0",
+ "arrow-buffer 51.0.0",
+ "arrow-data 51.0.0",
+ "arrow-schema 51.0.0",
+ "arrow-select 51.0.0",
+ "memchr",
+ "num",
+ "regex",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -2300,7 +2518,7 @@ dependencies = [
  "pallet-commitments",
  "parity-scale-codec",
  "proof-of-sql-commitment-map",
- "snafu",
+ "snafu 0.8.5",
  "sp-core",
  "sxt-core",
  "sxt-runtime",
@@ -3274,7 +3492,7 @@ dependencies = [
  "lazy_static",
  "log",
  "prometheus 0.14.0",
- "snafu",
+ "snafu 0.8.5",
  "subxt",
  "sxt-core",
  "sxt-runtime",
@@ -3431,6 +3649,28 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59ae0466b83e838b81a54256c39d5d7c20b9d7daa10510a242d9b75abd5936e"
+dependencies = [
+ "chrono",
+ "chrono-tz-build",
+ "phf",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "433e39f13c9a060046954e0592a8d0a4bcb1040125cbf91cb8ee58964cfb350f"
+dependencies = [
+ "parse-zoneinfo",
+ "phf",
+ "phf_codegen",
 ]
 
 [[package]]
@@ -3611,7 +3851,7 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "snafu",
+ "snafu 0.8.5",
  "sxt-core",
 ]
 
@@ -3631,7 +3871,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rayon",
- "snafu",
+ "snafu 0.8.5",
  "sqlparser",
  "sxt-core",
 ]
@@ -4579,14 +4819,14 @@ dependencies = [
  "lazy_static",
  "log",
  "num-bigint",
- "object_store",
+ "object_store 0.11.2",
  "parquet",
  "pg_bigdecimal",
  "regex",
  "rust_decimal",
  "serde",
  "serde_json",
- "snafu",
+ "snafu 0.8.5",
  "tokio",
  "tokio-postgres",
  "tokio-stream",
@@ -4594,6 +4834,268 @@ dependencies = [
  "tonic",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "datafusion"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05fb4eeeb7109393a0739ac5b8fd892f95ccef691421491c85544f7997366f68"
+dependencies = [
+ "ahash 0.8.11",
+ "arrow 51.0.0",
+ "arrow-array 51.0.0",
+ "arrow-ipc 51.0.0",
+ "arrow-schema 51.0.0",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "dashmap 5.5.3",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions",
+ "datafusion-functions-aggregate",
+ "datafusion-optimizer",
+ "datafusion-physical-expr",
+ "datafusion-physical-plan",
+ "datafusion-sql",
+ "futures",
+ "glob",
+ "half",
+ "hashbrown 0.14.5",
+ "indexmap 2.8.0",
+ "itertools 0.12.1",
+ "log",
+ "num_cpus",
+ "object_store 0.9.1",
+ "parking_lot 0.12.3",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "sqlparser",
+ "tempfile",
+ "tokio",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "datafusion-common"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "741aeac15c82f239f2fc17deccaab19873abbd62987be20023689b15fa72fa09"
+dependencies = [
+ "ahash 0.8.11",
+ "arrow 51.0.0",
+ "arrow-array 51.0.0",
+ "arrow-buffer 51.0.0",
+ "arrow-schema 51.0.0",
+ "chrono",
+ "half",
+ "instant",
+ "libc",
+ "num_cpus",
+ "object_store 0.9.1",
+ "sqlparser",
+]
+
+[[package]]
+name = "datafusion-common-runtime"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e8ddfb8d8cb51646a30da0122ecfffb81ca16919ae9a3495a9e7468bdcd52b8"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-execution"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282122f90b20e8f98ebfa101e4bf20e718fd2684cf81bef4e8c6366571c64404"
+dependencies = [
+ "arrow 51.0.0",
+ "chrono",
+ "dashmap 5.5.3",
+ "datafusion-common",
+ "datafusion-expr",
+ "futures",
+ "hashbrown 0.14.5",
+ "log",
+ "object_store 0.9.1",
+ "parking_lot 0.12.3",
+ "rand 0.8.5",
+ "tempfile",
+ "url",
+]
+
+[[package]]
+name = "datafusion-expr"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5478588f733df0dfd87a62671c7478f590952c95fa2fa5c137e3ff2929491e22"
+dependencies = [
+ "ahash 0.8.11",
+ "arrow 51.0.0",
+ "arrow-array 51.0.0",
+ "chrono",
+ "datafusion-common",
+ "paste",
+ "serde_json",
+ "sqlparser",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "datafusion-functions"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4afd261cea6ac9c3ca1192fd5e9f940596d8e9208c5b1333f4961405db53185"
+dependencies = [
+ "arrow 51.0.0",
+ "base64 0.22.1",
+ "chrono",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr",
+ "hashbrown 0.14.5",
+ "hex",
+ "itertools 0.12.1",
+ "log",
+ "rand 0.8.5",
+ "regex",
+ "unicode-segmentation",
+ "uuid",
+]
+
+[[package]]
+name = "datafusion-functions-aggregate"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b36a6c4838ab94b5bf8f7a96ce6ce059d805c5d1dcaa6ace49e034eb65cd999"
+dependencies = [
+ "arrow 51.0.0",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr-common",
+ "log",
+ "paste",
+ "sqlparser",
+]
+
+[[package]]
+name = "datafusion-optimizer"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54f2820938810e8a2d71228fd6f59f33396aebc5f5f687fcbf14de5aab6a7e1a"
+dependencies = [
+ "arrow 51.0.0",
+ "async-trait",
+ "chrono",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-physical-expr",
+ "hashbrown 0.14.5",
+ "indexmap 2.8.0",
+ "itertools 0.12.1",
+ "log",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "datafusion-physical-expr"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9adf8eb12716f52ddf01e09eb6c94d3c9b291e062c05c91b839a448bddba2ff8"
+dependencies = [
+ "ahash 0.8.11",
+ "arrow 51.0.0",
+ "arrow-array 51.0.0",
+ "arrow-buffer 51.0.0",
+ "arrow-ord 51.0.0",
+ "arrow-schema 51.0.0",
+ "arrow-string 51.0.0",
+ "base64 0.22.1",
+ "chrono",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions-aggregate",
+ "datafusion-physical-expr-common",
+ "half",
+ "hashbrown 0.14.5",
+ "hex",
+ "indexmap 2.8.0",
+ "itertools 0.12.1",
+ "log",
+ "paste",
+ "petgraph 0.6.5",
+ "regex",
+]
+
+[[package]]
+name = "datafusion-physical-expr-common"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d5472c3230584c150197b3f2c23f2392b9dc54dbfb62ad41e7e36447cfce4be"
+dependencies = [
+ "arrow 51.0.0",
+ "datafusion-common",
+ "datafusion-expr",
+]
+
+[[package]]
+name = "datafusion-physical-plan"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18ae750c38389685a8b62e5b899bbbec488950755ad6d218f3662d35b800c4fe"
+dependencies = [
+ "ahash 0.8.11",
+ "arrow 51.0.0",
+ "arrow-array 51.0.0",
+ "arrow-buffer 51.0.0",
+ "arrow-ord 51.0.0",
+ "arrow-schema 51.0.0",
+ "async-trait",
+ "chrono",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions-aggregate",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "futures",
+ "half",
+ "hashbrown 0.14.5",
+ "indexmap 2.8.0",
+ "itertools 0.12.1",
+ "log",
+ "once_cell",
+ "parking_lot 0.12.3",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-sql"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "befc67a3cdfbfa76853f43b10ac27337821bb98e519ab6baf431fcc0bcfcafdb"
+dependencies = [
+ "arrow 51.0.0",
+ "arrow-array 51.0.0",
+ "arrow-schema 51.0.0",
+ "datafusion-common",
+ "datafusion-expr",
+ "log",
+ "sqlparser",
+ "strum 0.26.3",
 ]
 
 [[package]]
@@ -4864,6 +5366,12 @@ dependencies = [
  "quote",
  "syn 2.0.99",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "docify"
@@ -5308,7 +5816,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde_json",
  "sha3",
- "snafu",
+ "snafu 0.8.5",
  "sp-core",
  "subxt",
  "subxt-signer",
@@ -5535,6 +6043,16 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flatbuffers"
+version = "23.5.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dac53e22462d78c16d64a1cd22371b54cc3fe94aa15e7886a2fa6e5d1ab8640"
+dependencies = [
+ "bitflags 1.3.2",
+ "rustc_version 0.4.1",
+]
 
 [[package]]
 name = "flatbuffers"
@@ -7156,6 +7674,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -7592,15 +8113,39 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lexical-core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cde5de06e8d4c2faabc400238f9ae1c74d5412d03a7bd067645ccbc47070e46"
+dependencies = [
+ "lexical-parse-float 0.8.5",
+ "lexical-parse-integer 0.8.6",
+ "lexical-util 0.8.5",
+ "lexical-write-float 0.8.5",
+ "lexical-write-integer 0.8.5",
+]
+
+[[package]]
+name = "lexical-core"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b765c31809609075565a70b4b71402281283aeda7ecaf4818ac14a7b2ade8958"
 dependencies = [
- "lexical-parse-float",
- "lexical-parse-integer",
- "lexical-util",
- "lexical-write-float",
- "lexical-write-integer",
+ "lexical-parse-float 1.0.5",
+ "lexical-parse-integer 1.0.5",
+ "lexical-util 1.0.6",
+ "lexical-write-float 1.0.5",
+ "lexical-write-integer 1.0.5",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683b3a5ebd0130b8fb52ba0bdc718cc56815b6a097e28ae5a6997d0ad17dc05f"
+dependencies = [
+ "lexical-parse-integer 0.8.6",
+ "lexical-util 0.8.5",
+ "static_assertions",
 ]
 
 [[package]]
@@ -7609,8 +8154,18 @@ version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de6f9cb01fb0b08060209a057c048fcbab8717b4c1ecd2eac66ebfe39a65b0f2"
 dependencies = [
- "lexical-parse-integer",
- "lexical-util",
+ "lexical-parse-integer 1.0.5",
+ "lexical-util 1.0.6",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d0994485ed0c312f6d965766754ea177d07f9c00c9b82a5ee62ed5b47945ee9"
+dependencies = [
+ "lexical-util 0.8.5",
  "static_assertions",
 ]
 
@@ -7620,7 +8175,16 @@ version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72207aae22fc0a121ba7b6d479e42cbfea549af1479c3f3a4f12c70dd66df12e"
 dependencies = [
- "lexical-util",
+ "lexical-util 1.0.6",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-util"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5255b9ff16ff898710eb9eb63cb39248ea8a5bb036bea8085b1a767ff6c4e3fc"
+dependencies = [
  "static_assertions",
 ]
 
@@ -7635,12 +8199,33 @@ dependencies = [
 
 [[package]]
 name = "lexical-write-float"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accabaa1c4581f05a3923d1b4cfd124c329352288b7b9da09e766b0668116862"
+dependencies = [
+ "lexical-util 0.8.5",
+ "lexical-write-integer 0.8.5",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-float"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5afc668a27f460fb45a81a757b6bf2f43c2d7e30cb5a2dcd3abf294c78d62bd"
 dependencies = [
- "lexical-util",
- "lexical-write-integer",
+ "lexical-util 1.0.6",
+ "lexical-write-integer 1.0.5",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b6f3d1f4422866b68192d62f77bc5c700bee84f3069f2469d7bc8c77852446"
+dependencies = [
+ "lexical-util 0.8.5",
  "static_assertions",
 ]
 
@@ -7650,7 +8235,7 @@ version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "629ddff1a914a836fb245616a7888b62903aae58fa771e1d83943035efa0f978"
 dependencies = [
- "lexical-util",
+ "lexical-util 1.0.6",
  "static_assertions",
 ]
 
@@ -9035,9 +9620,14 @@ version = "0.1.0"
 dependencies = [
  "attestation_tree",
  "bincode 2.0.0",
+ "commitment-sql",
+ "datafusion",
  "frame-support",
+ "hex",
  "indexmap 2.8.0",
+ "itertools 0.12.1",
  "jsonrpsee",
+ "on-chain-table",
  "pallet-attestation",
  "pallet-balances",
  "pallet-system-contracts",
@@ -9045,6 +9635,8 @@ dependencies = [
  "parity-scale-codec",
  "proof-of-sql",
  "proof-of-sql-commitment-map",
+ "proof-of-sql-planner",
+ "proof-of-sql-static-setups",
  "sc-chain-spec",
  "sc-client-api",
  "sc-consensus-babe",
@@ -9055,7 +9647,7 @@ dependencies = [
  "sc-sync-state-rpc",
  "sc-transaction-pool-api",
  "serde",
- "snafu",
+ "snafu 0.8.5",
  "sp-api",
  "sp-block-builder",
  "sp-blockchain",
@@ -9065,6 +9657,7 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "sp-statement-store",
+ "sqlparser",
  "substrate-frame-rpc-system",
  "substrate-state-trie-migration-rpc",
  "sxt-core",
@@ -9304,6 +9897,27 @@ dependencies = [
 
 [[package]]
 name = "object_store"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8718f8b65fdf67a45108d1548347d4af7d71fb81ce727bbf9e3b2535e079db3"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "humantime",
+ "itertools 0.12.1",
+ "parking_lot 0.12.3",
+ "percent-encoding",
+ "snafu 0.7.5",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+]
+
+[[package]]
+name = "object_store"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cfccb68961a56facde1163f9319e0d15743352344e7808a11795fb99698dcaf"
@@ -9325,7 +9939,7 @@ dependencies = [
  "ring 0.17.12",
  "serde",
  "serde_json",
- "snafu",
+ "snafu 0.8.5",
  "tokio",
  "tracing",
  "url",
@@ -9360,7 +9974,7 @@ dependencies = [
  "primitive-types 0.12.2",
  "proof-of-sql",
  "serde",
- "snafu",
+ "snafu 0.8.5",
  "sqlparser",
 ]
 
@@ -11897,6 +12511,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse-zoneinfo"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "partial_sort"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12046,6 +12669,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -13149,6 +13792,7 @@ dependencies = [
  "ark-poly 0.5.0",
  "ark-serialize 0.5.0",
  "ark-std 0.5.0",
+ "arrow 51.0.0",
  "bigdecimal 0.4.7",
  "bincode 2.0.0",
  "bit-iter",
@@ -13171,7 +13815,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "snafu",
+ "snafu 0.8.5",
  "sqlparser",
  "sysinfo",
  "tiny-keccak",
@@ -13195,7 +13839,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "scale-info",
  "serde",
- "snafu",
+ "snafu 0.8.5",
  "sp-core",
  "sp-runtime-interface",
  "sqlparser",
@@ -13214,8 +13858,26 @@ dependencies = [
  "lalrpop",
  "lalrpop-util",
  "serde",
- "snafu",
+ "snafu 0.8.5",
  "sqlparser",
+]
+
+[[package]]
+name = "proof-of-sql-planner"
+version = "0.99.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2b58418cb80a1b048e2e7710c51a2b09b36fc17444e8f4ba4ffb29e5d2f468"
+dependencies = [
+ "ahash 0.8.11",
+ "arrow 51.0.0",
+ "datafusion",
+ "getrandom 0.2.15",
+ "indexmap 2.8.0",
+ "proof-of-sql",
+ "serde",
+ "snafu 0.8.5",
+ "sqlparser",
+ "uuid",
 ]
 
 [[package]]
@@ -13237,7 +13899,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "sha2 0.10.8",
- "snafu",
+ "snafu 0.8.5",
  "tokio",
  "url",
 ]
@@ -16679,11 +17341,33 @@ dependencies = [
 
 [[package]]
 name = "snafu"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4de37ad025c587a29e8f3f5605c00f70b98715ef90b9061a815b9e59e9042d6"
+dependencies = [
+ "doc-comment",
+ "snafu-derive 0.7.5",
+]
+
+[[package]]
+name = "snafu"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "223891c85e2a29c3fe8fb900c1fae5e69c2e42415e3177752e8718475efa5019"
 dependencies = [
- "snafu-derive",
+ "snafu-derive 0.8.5",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990079665f075b699031e9c08fd3ab99be5029b96f3b78dc0709e8f77e4efebf"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -17958,6 +18642,17 @@ source = "git+https://github.com/tlovell-sxt/datafusion-sqlparser-rs.git?rev=a82
 dependencies = [
  "log",
  "serde",
+ "sqlparser_derive",
+]
+
+[[package]]
+name = "sqlparser_derive"
+version = "0.2.2"
+source = "git+https://github.com/tlovell-sxt/datafusion-sqlparser-rs.git?rev=a828cbea22cf19bb6b4596f902bdd6f4d14a00b8#a828cbea22cf19bb6b4596f902bdd6f4d14a00b8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -18592,7 +19287,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
- "snafu",
+ "snafu 0.8.5",
  "sp-api",
  "sp-blockchain",
  "sp-core",
@@ -18606,7 +19301,7 @@ dependencies = [
 
 [[package]]
 name = "sxt-node"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "bs58 0.5.1",
  "clap 4.5.32",
@@ -19513,7 +20208,7 @@ dependencies = [
  "linked-list",
  "log",
  "serde",
- "snafu",
+ "snafu 0.8.5",
  "subxt",
  "subxt-signer",
  "sxt-core",
@@ -19931,6 +20626,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
 dependencies = [
  "getrandom 0.3.1",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -20481,7 +21178,7 @@ dependencies = [
  "prometheus 0.12.0",
  "ratatui",
  "sha3",
- "snafu",
+ "snafu 0.8.5",
  "sp-core",
  "subxt",
  "subxt-signer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ bincode = { version = "2.0.0", default-features = false }
 const_format = { version = "0.2.33", default-features = false }
 commitment-sql = { path = "./proof-of-sql/commitment-sql/", default-features = false }
 data-loader = { path = "./data-loader", default-features = false }
+datafusion = { version = "38.0.0", default-features = false }
 arrow-flight = { version = "54.2.1", default-features = false }
 sxt-runtime = { path = "./runtime", default-features = false }
 pallet-commitments = { path = "./pallets/commitments", default-features = false }
@@ -85,6 +86,7 @@ on-chain-table = { path = "./proof-of-sql/on-chain-table/", default-features = f
 postcard = { version = "1.0.10", default-features = false }
 primitive-types = { version = "0.12.2", default-features = false }
 proof-of-sql = { version = "0.99.0", default-features = false }
+proof-of-sql-planner = { version = "0.99.0", default-features = false }
 proof-of-sql-commitment-map = { path = "./proof-of-sql/commitment-map/", default-features = false }
 proof-of-sql-static-setups = { path = "./proof-of-sql/static-setups/", default-features = false }
 rand = { version = "0.8.5", default-features = false }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sxt-node"
 description = "The Space and Time Transaction Node"
-version = "1.0.0"
+version = "1.1.0"
 license = "Unlicense"
 authors.workspace = true
 homepage.workspace = true

--- a/pallets/commitments/Cargo.toml
+++ b/pallets/commitments/Cargo.toml
@@ -28,6 +28,8 @@ on-chain-table.workspace = true
 proof-of-sql.workspace = true
 proof-of-sql-commitment-map = { workspace = true, features = ["substrate"] }
 proof-of-sql-static-setups = { workspace = true, features = ["baked"] }
+sp-core.workspace = true
+sp-api.workspace = true
 sqlparser.workspace = true
 sxt-core.workspace = true
 
@@ -44,7 +46,9 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 	"scale-info/std",
+	"sp-api/std",
 	"native-api/std",
+	"sp-core/std",
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",

--- a/pallets/commitments/src/lib.rs
+++ b/pallets/commitments/src/lib.rs
@@ -26,6 +26,7 @@ mod test_table_commitments;
 
 mod error_conversions;
 
+pub mod runtime_api;
 pub use pallet::*;
 
 #[allow(clippy::manual_inspect)]

--- a/pallets/commitments/src/runtime_api.rs
+++ b/pallets/commitments/src/runtime_api.rs
@@ -1,0 +1,32 @@
+//! Runtime APIs for reading from pallet-commitments.
+
+use alloc::vec::Vec;
+
+use frame_support::BoundedVec;
+use proof_of_sql_commitment_map::generic_over_commitment::ConcreteType;
+use proof_of_sql_commitment_map::{AnyCommitmentScheme, TableCommitmentBytes};
+use sp_core::ConstU32;
+use sxt_core::tables::TableIdentifier;
+
+use super::AnyTableCommitments;
+
+/// The maximum table commitments that can be requested in commitments apis.
+pub const MAX_TABLES_IN_TABLE_COMMITMENTS_QUERY: u32 = 64;
+
+/// The maximum table commitments that can be requested in commitments apis as `Get`.
+pub type MaxTablesInTableCommitmentsQuery = ConstU32<MAX_TABLES_IN_TABLE_COMMITMENTS_QUERY>;
+
+/// A bounded list of table identifiers used as input in commitments apis.
+pub type CommitmentsApiBoundedTableIdentifiersList =
+    BoundedVec<TableIdentifier, MaxTablesInTableCommitmentsQuery>;
+
+sp_api::decl_runtime_apis! {
+    /// Runtime APIs for reading from pallet-commitments.
+    pub trait CommitmentsApi {
+        /// Returns the table commitments for the given table identifiers, for the first scheme
+        /// that covers all of them.
+        ///
+        /// Returns `None` if no scheme has complete coverage of the given tables.
+        fn table_commitments_any_scheme(table_identifiers: CommitmentsApiBoundedTableIdentifiersList) -> Option<AnyTableCommitments>;
+    }
+}

--- a/pallets/commitments/src/test_table_commitments.rs
+++ b/pallets/commitments/src/test_table_commitments.rs
@@ -1,0 +1,84 @@
+use alloc::vec;
+
+use proof_of_sql_commitment_map::{AnyCommitmentScheme, CommitmentScheme, TableCommitmentBytes};
+use sxt_core::tables::TableIdentifier;
+
+use crate::mock::{new_test_ext, CommitmentsModule, Test};
+
+fn fake_commitment(seed: u8) -> TableCommitmentBytes {
+    TableCommitmentBytes {
+        data: vec![seed; seed as usize].try_into().unwrap(),
+    }
+}
+
+#[test]
+fn we_can_get_table_commitments_of_any_scheme() {
+    new_test_ext().execute_with(|| {
+        let table_id_0 = TableIdentifier {
+            namespace: b"ANIMAL".to_vec().try_into().unwrap(),
+            name: b"POPULATION".to_vec().try_into().unwrap(),
+        };
+        let table_id_1 = TableIdentifier {
+            namespace: b"LUMBER".to_vec().try_into().unwrap(),
+            name: b"YARDS".to_vec().try_into().unwrap(),
+        };
+
+        let tables = [table_id_0.clone(), table_id_1.clone()];
+
+        // no commitments for any scheme
+        assert_eq!(
+            CommitmentsModule::table_commitments_any_scheme(&tables),
+            None
+        );
+
+        // no commitments for one scheme, incomplete commitments for the other
+        crate::CommitmentStorageMap::<Test>::insert(
+            &table_id_0,
+            CommitmentScheme::DynamicDory,
+            fake_commitment(0),
+        );
+        assert_eq!(
+            CommitmentsModule::table_commitments_any_scheme(&tables),
+            None
+        );
+
+        // incomplete commitments for both schemes
+        crate::CommitmentStorageMap::<Test>::insert(
+            &table_id_1,
+            CommitmentScheme::HyperKzg,
+            fake_commitment(1),
+        );
+        assert_eq!(
+            CommitmentsModule::table_commitments_any_scheme(&tables),
+            None
+        );
+
+        // incomplete commitments for one scheme, complete commitments for the other
+        crate::CommitmentStorageMap::<Test>::insert(
+            &table_id_1,
+            CommitmentScheme::DynamicDory,
+            fake_commitment(2),
+        );
+        assert_eq!(
+            CommitmentsModule::table_commitments_any_scheme(&tables),
+            Some(AnyCommitmentScheme::DynamicDory(vec![
+                fake_commitment(0),
+                fake_commitment(2)
+            ])),
+        );
+
+        // complete commitments for both (variant order determines priority)
+        crate::CommitmentStorageMap::<Test>::insert(
+            &table_id_0,
+            CommitmentScheme::HyperKzg,
+            fake_commitment(3),
+        );
+        assert_eq!(
+            CommitmentsModule::table_commitments_any_scheme(&tables),
+            Some(AnyCommitmentScheme::HyperKzg(vec![
+                fake_commitment(3),
+                fake_commitment(1)
+            ])),
+        );
+    })
+}

--- a/proof-of-sql/commitment-map/src/commitment_scheme.rs
+++ b/proof-of-sql/commitment-map/src/commitment_scheme.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "substrate")]
 use frame_support::pallet_prelude::{Decode, Encode, MaxEncodedLen};
+use proof_of_sql::base::commitment::Commitment;
 use proof_of_sql::proof_primitive::dory::DynamicDoryCommitment;
 use proof_of_sql::proof_primitive::hyperkzg::HyperKZGCommitment;
 #[cfg(feature = "substrate")]
@@ -23,6 +24,20 @@ pub enum CommitmentScheme {
     HyperKzg,
     /// Scheme with dory commitments.
     DynamicDory,
+}
+
+/// Trait for commitment types that defines their associated [`CommitmentScheme`].
+pub trait CommitmentId: Commitment + Serialize + for<'de> Deserialize<'de> {
+    /// The [`CommitmentScheme`] associated with this commitment type.
+    const COMMITMENT_SCHEME: CommitmentScheme;
+}
+
+impl CommitmentId for HyperKZGCommitment {
+    const COMMITMENT_SCHEME: CommitmentScheme = CommitmentScheme::HyperKzg;
+}
+
+impl CommitmentId for DynamicDoryCommitment {
+    const COMMITMENT_SCHEME: CommitmentScheme = CommitmentScheme::DynamicDory;
 }
 
 /// Flags for selecting a combination of proof-of-sql commitment schemes.

--- a/proof-of-sql/commitment-map/src/commitment_scheme.rs
+++ b/proof-of-sql/commitment-map/src/commitment_scheme.rs
@@ -26,6 +26,16 @@ pub enum CommitmentScheme {
     DynamicDory,
 }
 
+impl CommitmentScheme {
+    /// Returns `AnyCommitmentScheme(value)` with the appropriate [`CommitmentScheme`] variant.
+    pub fn into_any_concrete<T>(self, value: T) -> AnyCommitmentScheme<ConcreteType<T>> {
+        match self {
+            CommitmentScheme::HyperKzg => AnyCommitmentScheme::HyperKzg(value),
+            CommitmentScheme::DynamicDory => AnyCommitmentScheme::DynamicDory(value),
+        }
+    }
+}
+
 /// Trait for commitment types that defines their associated [`CommitmentScheme`].
 pub trait CommitmentId: Commitment + Serialize + for<'de> Deserialize<'de> {
     /// The [`CommitmentScheme`] associated with this commitment type.
@@ -720,5 +730,17 @@ mod tests {
 
         let dory_usize = AnyCommitmentScheme::<ConcreteType<usize>>::DynamicDory(456);
         assert_eq!(dory_usize.unwrap(), 456);
+    }
+
+    #[test]
+    fn we_can_convert_commitment_scheme_into_any_commitment_scheme_with_value() {
+        assert_eq!(
+            CommitmentScheme::HyperKzg.into_any_concrete(123),
+            AnyCommitmentScheme::HyperKzg(123)
+        );
+        assert_eq!(
+            CommitmentScheme::DynamicDory.into_any_concrete(456),
+            AnyCommitmentScheme::DynamicDory(456)
+        );
     }
 }

--- a/proof-of-sql/commitment-map/src/generic_over_commitment.rs
+++ b/proof-of-sql/commitment-map/src/generic_over_commitment.rs
@@ -6,14 +6,11 @@ use core::marker::PhantomData;
 
 #[cfg(feature = "substrate")]
 use frame_support::pallet_prelude::{Decode, Encode, MaxEncodedLen};
-use proof_of_sql::base::commitment::{
-    ColumnCommitments,
-    Commitment,
-    QueryCommitments,
-    TableCommitment,
-};
+use proof_of_sql::base::commitment::{ColumnCommitments, QueryCommitments, TableCommitment};
 #[cfg(feature = "substrate")]
 use scale_info::TypeInfo;
+
+use crate::CommitmentId;
 
 /// Abstraction for types that are generic over commitments.
 ///
@@ -23,7 +20,7 @@ use scale_info::TypeInfo;
 /// - doesn't actually care about the specifics of the type, just that it is commitment-generic.
 pub trait GenericOverCommitment {
     /// Generic type associated with this concrete type.
-    type WithCommitment<C: Commitment>;
+    type WithCommitment<C: CommitmentId>;
 }
 
 /// Concrete type associated with `Commitment` implementors.
@@ -32,34 +29,34 @@ pub trait GenericOverCommitment {
 pub struct CommitmentType;
 
 impl GenericOverCommitment for CommitmentType {
-    type WithCommitment<C: Commitment> = C;
+    type WithCommitment<C: CommitmentId> = C;
 }
 
-/// Concrete type associated with the generic `ColumnCommitments<C: Commitment>`.
+/// Concrete type associated with the generic `ColumnCommitments<C: CommitmentId>`.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "substrate", derive(Decode, Encode, MaxEncodedLen, TypeInfo))]
 pub struct ColumnCommitmentsType;
 
 impl GenericOverCommitment for ColumnCommitmentsType {
-    type WithCommitment<C: Commitment> = ColumnCommitments<C>;
+    type WithCommitment<C: CommitmentId> = ColumnCommitments<C>;
 }
 
-/// Concrete type associated with the generic `TableCommitment<C: Commitment>`.
+/// Concrete type associated with the generic `TableCommitment<C: CommitmentId>`.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "substrate", derive(Decode, Encode, MaxEncodedLen, TypeInfo))]
 pub struct TableCommitmentType;
 
 impl GenericOverCommitment for TableCommitmentType {
-    type WithCommitment<C: Commitment> = TableCommitment<C>;
+    type WithCommitment<C: CommitmentId> = TableCommitment<C>;
 }
 
-/// Concrete type associated with the generic `QueryCommitments<C: Commitment>`.
+/// Concrete type associated with the generic `QueryCommitments<C: CommitmentId>`.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "substrate", derive(Decode, Encode, MaxEncodedLen, TypeInfo))]
 pub struct QueryCommitmentsType;
 
 impl GenericOverCommitment for QueryCommitmentsType {
-    type WithCommitment<C: Commitment> = QueryCommitments<C>;
+    type WithCommitment<C: CommitmentId> = QueryCommitments<C>;
 }
 
 /// Concrete type associated with `Commitment` implementors' `C::PublicSetup` types.
@@ -68,7 +65,7 @@ impl GenericOverCommitment for QueryCommitmentsType {
 pub struct AssociatedPublicSetupType<'a>(PhantomData<&'a ()>);
 
 impl<'a> GenericOverCommitment for AssociatedPublicSetupType<'a> {
-    type WithCommitment<C: Commitment> = C::PublicSetup<'a>;
+    type WithCommitment<C: CommitmentId> = C::PublicSetup<'a>;
 }
 
 /// Concrete type associated with `Commitment` implementors' `C::Scalar` types.
@@ -77,25 +74,25 @@ impl<'a> GenericOverCommitment for AssociatedPublicSetupType<'a> {
 pub struct AssociatedScalarType;
 
 impl GenericOverCommitment for AssociatedScalarType {
-    type WithCommitment<C: Commitment> = C::Scalar;
+    type WithCommitment<C: CommitmentId> = C::Scalar;
 }
 
-/// Concrete type associated with `Option<G::WithCommitment<C: Commitment>>` types.
+/// Concrete type associated with `Option<G::WithCommitment<C: CommitmentId>>` types.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "substrate", derive(Decode, Encode, MaxEncodedLen, TypeInfo))]
 pub struct OptionType<G: GenericOverCommitment>(PhantomData<G>);
 
 impl<G: GenericOverCommitment> GenericOverCommitment for OptionType<G> {
-    type WithCommitment<C: Commitment> = Option<G::WithCommitment<C>>;
+    type WithCommitment<C: CommitmentId> = Option<G::WithCommitment<C>>;
 }
 
-/// Concrete type associated with `Result<G::WithCommitment<C: Commitment>, E>` types.
+/// Concrete type associated with `Result<G::WithCommitment<C: CommitmentId>, E>` types.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "substrate", derive(Decode, Encode, MaxEncodedLen, TypeInfo))]
 pub struct ResultOkType<G: GenericOverCommitment, E>(PhantomData<G>, PhantomData<E>);
 
 impl<G: GenericOverCommitment, E> GenericOverCommitment for ResultOkType<G, E> {
-    type WithCommitment<C: Commitment> = Result<G::WithCommitment<C>, E>;
+    type WithCommitment<C: CommitmentId> = Result<G::WithCommitment<C>, E>;
 }
 
 /// Concrete type associated with a 2-tuple `(G0::WithCommitment<C>, G1::WithCommitment<C>)`.
@@ -109,7 +106,7 @@ pub struct PairType<G0: GenericOverCommitment, G1: GenericOverCommitment>(
 impl<G0: GenericOverCommitment, G1: GenericOverCommitment> GenericOverCommitment
     for PairType<G0, G1>
 {
-    type WithCommitment<C: Commitment> = (G0::WithCommitment<C>, G1::WithCommitment<C>);
+    type WithCommitment<C: CommitmentId> = (G0::WithCommitment<C>, G1::WithCommitment<C>);
 }
 
 /// Concrete type associated with `T`, which is not necessarily generic over commitments.
@@ -118,5 +115,5 @@ impl<G0: GenericOverCommitment, G1: GenericOverCommitment> GenericOverCommitment
 pub struct ConcreteType<T>(PhantomData<T>);
 
 impl<T> GenericOverCommitment for ConcreteType<T> {
-    type WithCommitment<C: Commitment> = T;
+    type WithCommitment<C: CommitmentId> = T;
 }

--- a/proof-of-sql/commitment-map/src/generic_over_commitment_fn.rs
+++ b/proof-of-sql/commitment-map/src/generic_over_commitment_fn.rs
@@ -1,6 +1,5 @@
-use proof_of_sql::base::commitment::Commitment;
-
 use crate::generic_over_commitment::GenericOverCommitment;
+use crate::CommitmentId;
 
 /// Trait for writing functions that are generic over commitments.
 ///
@@ -14,7 +13,7 @@ pub trait GenericOverCommitmentFn {
     type Out: GenericOverCommitment;
 
     /// Mapping function that is generic over commitment.
-    fn call<C: Commitment>(
+    fn call<C: CommitmentId>(
         &self,
         input: <Self::In as GenericOverCommitment>::WithCommitment<C>,
     ) -> <Self::Out as GenericOverCommitment>::WithCommitment<C>;
@@ -27,7 +26,7 @@ where
     type In = F::In;
     type Out = F::Out;
 
-    fn call<C: Commitment>(
+    fn call<C: CommitmentId>(
         &self,
         input: <Self::In as GenericOverCommitment>::WithCommitment<C>,
     ) -> <Self::Out as GenericOverCommitment>::WithCommitment<C> {
@@ -39,8 +38,8 @@ where
 pub mod tests {
     use core::marker::PhantomData;
 
-    use curve25519_dalek::RistrettoPoint;
     use proof_of_sql::proof_primitive::dory::DynamicDoryCommitment;
+    use proof_of_sql::proof_primitive::hyperkzg::HyperKZGCommitment;
 
     use super::*;
     use crate::generic_over_commitment::{CommitmentType, OptionType};
@@ -57,7 +56,7 @@ pub mod tests {
         type In = T;
         type Out = OptionType<T>;
 
-        fn call<C: Commitment>(
+        fn call<C: CommitmentId>(
             &self,
             input: <Self::In as GenericOverCommitment>::WithCommitment<C>,
         ) -> <Self::Out as GenericOverCommitment>::WithCommitment<C> {
@@ -70,7 +69,7 @@ pub mod tests {
         let some_fn = SomeFn::<CommitmentType>::new();
 
         assert_eq!(
-            some_fn.call::<RistrettoPoint>(Default::default()),
+            some_fn.call::<HyperKZGCommitment>(Default::default()),
             Some(Default::default())
         );
 

--- a/proof-of-sql/commitment-map/src/lib.rs
+++ b/proof-of-sql/commitment-map/src/lib.rs
@@ -12,6 +12,7 @@ pub use generic_over_commitment_fn::GenericOverCommitmentFn;
 mod commitment_scheme;
 pub use commitment_scheme::{
     AnyCommitmentScheme,
+    CommitmentId,
     CommitmentScheme,
     CommitmentSchemeFlags,
     PerCommitmentScheme,

--- a/proof-of-sql/commitment-map/src/memory_commitment_map.rs
+++ b/proof-of-sql/commitment-map/src/memory_commitment_map.rs
@@ -81,6 +81,7 @@ mod tests {
 
     use super::*;
     use crate::{
+        CommitmentId,
         CommitmentMap,
         CommitmentSchemeFlags,
         CommitmentSchemesMismatchError,
@@ -94,12 +95,12 @@ mod tests {
     /// However, generating them for testing requires the blitzar feature.
     /// Enabling the blitzar feature complicates writing substrate-oriented tests.
     #[derive(Copy, Clone, PartialEq, Eq, Default, Debug)]
-    struct TestCommitmentMetadata<C: Commitment> {
+    struct TestCommitmentMetadata<C: CommitmentId> {
         metadata: usize,
         phantom_data: PhantomData<C>,
     }
 
-    impl<C: Commitment> TestCommitmentMetadata<C> {
+    impl<C: CommitmentId> TestCommitmentMetadata<C> {
         /// Construct a new [`TestCommitmentMetadata`].
         fn new(metadata: usize) -> Self {
             TestCommitmentMetadata {
@@ -113,7 +114,7 @@ mod tests {
     struct TestCommitmentMetadataType;
 
     impl GenericOverCommitment for TestCommitmentMetadataType {
-        type WithCommitment<C: Commitment> = TestCommitmentMetadata<C>;
+        type WithCommitment<C: CommitmentId> = TestCommitmentMetadata<C>;
     }
 
     struct CombinationsCommitmentMapRefs {

--- a/proof-of-sql/commitment-sql/src/create_table.rs
+++ b/proof-of-sql/commitment-sql/src/create_table.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 use core::marker::PhantomData;
 
 use on_chain_table::{OnChainTable, OutOfScalarBounds};
-use proof_of_sql::base::commitment::{Commitment, TableCommitment};
+use proof_of_sql::base::commitment::TableCommitment;
 use proof_of_sql_commitment_map::generic_over_commitment::{
     AssociatedPublicSetupType,
     GenericOverCommitment,
@@ -12,6 +12,7 @@ use proof_of_sql_commitment_map::generic_over_commitment::{
     TableCommitmentType,
 };
 use proof_of_sql_commitment_map::{
+    CommitmentId,
     CommitmentSchemeFlags,
     GenericOverCommitmentFn,
     PerCommitmentScheme,
@@ -37,7 +38,7 @@ impl<'s> GenericOverCommitmentFn for OnChainTableToTableCommitmentFn<'_, 's> {
     type In = AssociatedPublicSetupType<'s>;
     type Out = ResultOkType<TableCommitmentType, OutOfScalarBounds>;
 
-    fn call<C: Commitment>(
+    fn call<C: CommitmentId>(
         &self,
         input: <Self::In as GenericOverCommitment>::WithCommitment<C>,
     ) -> <Self::Out as GenericOverCommitment>::WithCommitment<C> {

--- a/proof-of-sql/commitment-sql/src/create_table_from_snapshot.rs
+++ b/proof-of-sql/commitment-sql/src/create_table_from_snapshot.rs
@@ -6,7 +6,7 @@ use proof_of_sql_commitment_map::generic_over_commitment::{
     ResultOkType,
     TableCommitmentType,
 };
-use proof_of_sql_commitment_map::{GenericOverCommitmentFn, PerCommitmentScheme};
+use proof_of_sql_commitment_map::{CommitmentId, GenericOverCommitmentFn, PerCommitmentScheme};
 use snafu::Snafu;
 use sqlparser::ast::helpers::stmt_create_table::CreateTableBuilder;
 
@@ -20,7 +20,7 @@ impl GenericOverCommitmentFn for TryAddTableCommitmentsFn {
     type In = PairType<TableCommitmentType, TableCommitmentType>;
     type Out = ResultOkType<TableCommitmentType, TableCommitmentArithmeticError>;
 
-    fn call<C: proof_of_sql::base::commitment::Commitment>(
+    fn call<C: CommitmentId>(
             &self,
             input: <Self::In as proof_of_sql_commitment_map::generic_over_commitment::GenericOverCommitment>::WithCommitment<C>,
     ) -> <Self::Out as proof_of_sql_commitment_map::generic_over_commitment::GenericOverCommitment>::WithCommitment<C>{

--- a/proof-of-sql/commitment-sql/src/insert.rs
+++ b/proof-of-sql/commitment-sql/src/insert.rs
@@ -8,7 +8,6 @@ use proof_of_sql::base::commitment::{
     AppendColumnCommitmentsError,
     AppendTableCommitmentError,
     ColumnCommitmentsMismatch,
-    Commitment,
 };
 use proof_of_sql_commitment_map::generic_over_commitment::{
     AssociatedPublicSetupType,
@@ -19,7 +18,7 @@ use proof_of_sql_commitment_map::generic_over_commitment::{
     ResultOkType,
     TableCommitmentType,
 };
-use proof_of_sql_commitment_map::{GenericOverCommitmentFn, PerCommitmentScheme};
+use proof_of_sql_commitment_map::{CommitmentId, GenericOverCommitmentFn, PerCommitmentScheme};
 #[cfg(feature = "cpu-perf")]
 use rayon::prelude::*;
 use snafu::Snafu;
@@ -36,7 +35,7 @@ impl GenericOverCommitmentFn for GetColumnOrderFn {
     type In = TableCommitmentType;
     type Out = PairType<TableCommitmentType, ConcreteType<Vec<Ident>>>;
 
-    fn call<C: Commitment>(
+    fn call<C: CommitmentId>(
         &self,
         input: <Self::In as GenericOverCommitment>::WithCommitment<C>,
     ) -> <Self::Out as GenericOverCommitment>::WithCommitment<C> {
@@ -60,7 +59,7 @@ impl GenericOverCommitmentFn for GetTableCommitmentRangeEndFn {
     type In = TableCommitmentType;
     type Out = PairType<TableCommitmentType, ConcreteType<usize>>;
 
-    fn call<C: Commitment>(
+    fn call<C: CommitmentId>(
         &self,
         input: <Self::In as GenericOverCommitment>::WithCommitment<C>,
     ) -> <Self::Out as GenericOverCommitment>::WithCommitment<C> {
@@ -83,7 +82,7 @@ impl<T: GenericOverCommitment> GenericOverCommitmentFn for SomeFn<T> {
     type In = T;
     type Out = OptionType<T>;
 
-    fn call<C: Commitment>(
+    fn call<C: CommitmentId>(
         &self,
         input: <Self::In as GenericOverCommitment>::WithCommitment<C>,
     ) -> <Self::Out as GenericOverCommitment>::WithCommitment<C> {
@@ -110,7 +109,7 @@ impl<T: GenericOverCommitment, U: GenericOverCommitment> GenericOverCommitmentFn
     type In = PairType<OptionType<T>, OptionType<U>>;
     type Out = OptionType<PairType<T, U>>;
 
-    fn call<C: Commitment>(
+    fn call<C: CommitmentId>(
         &self,
         input: <Self::In as GenericOverCommitment>::WithCommitment<C>,
     ) -> <Self::Out as GenericOverCommitment>::WithCommitment<C> {
@@ -160,7 +159,7 @@ impl<'s> GenericOverCommitmentFn for AppendOnChainTableToTableCommitmentFn<'_, '
     type In = PairType<TableCommitmentType, AssociatedPublicSetupType<'s>>;
     type Out = ResultOkType<TableCommitmentType, AppendOnChainTableError>;
 
-    fn call<C: Commitment>(
+    fn call<C: CommitmentId>(
         &self,
         input: <Self::In as GenericOverCommitment>::WithCommitment<C>,
     ) -> <Self::Out as GenericOverCommitment>::WithCommitment<C> {

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -19,6 +19,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 attestation_tree.workspace = true
 bincode.workspace = true
 codec.workspace = true
+datafusion.workspace = true
 frame-support.workspace = true
 indexmap = { workspace = true }
 jsonrpsee = { features = ["server"], workspace = true }
@@ -27,6 +28,7 @@ pallet-transaction-payment-rpc = { workspace = true, default-features = true }
 pallet-balances = { workspace = true, default-features = true }
 pallet-system-contracts = { workspace = true, default-features = true }
 proof-of-sql = { workspace = true }
+proof-of-sql-planner = { workspace = true }
 proof-of-sql-commitment-map = { workspace = true }
 sc-chain-spec = { workspace = true, default-features = true }
 sc-client-api = { workspace = true, default-features = true }
@@ -48,7 +50,16 @@ sp-core = { workspace = true, default-features = true }
 sp-keystore = { workspace = true, default-features = true }
 sp-runtime = { workspace = true, default-features = true }
 sp-statement-store = { workspace = true, default-features = true }
+sqlparser = { workspace = true, features = ["std", "visitor"] }
 substrate-frame-rpc-system = { workspace = true, default-features = true }
 substrate-state-trie-migration-rpc = { workspace = true, default-features = true }
 sxt-core = { workspace = true }
 sxt-runtime = { workspace = true, default-features = false, features = ["std"] }
+
+hex.workspace = true
+
+[dev-dependencies]
+proof-of-sql-static-setups = { workspace = true, features = ["io"] }
+commitment-sql = { workspace = true }
+on-chain-table.workspace = true
+itertools.workspace = true

--- a/rpc/src/commitments/api.rs
+++ b/rpc/src/commitments/api.rs
@@ -28,6 +28,16 @@ pub struct VerifiableCommitmentsResponse<BH: Serialize> {
     pub at: BH,
 }
 
+/// Serialization format for an api response returning a proof plan.
+#[derive(Clone, PartialEq, Eq, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProofPlanResponse<BH: Serialize> {
+    /// The verifiable commitments.
+    pub proof_plan: Bytes,
+    /// The block hash that this query accessed storage with.
+    pub at: BH,
+}
+
 #[rpc(server)]
 pub trait CommitmentsApi<BH: Serialize> {
     /// Returns commitments + their merkle proofs for all tables in the proof-of-sql proof plan.
@@ -38,4 +48,20 @@ pub trait CommitmentsApi<BH: Serialize> {
         commitment_scheme: CommitmentScheme,
         at: Option<BH>,
     ) -> Result<VerifiableCommitmentsResponse<BH>, CommitmentsApiError>;
+
+    /// Returns proof plan for the given query text.
+    #[method(name = "commitments_v1_proofPlan", blocking)]
+    fn v1_proof_plan(
+        &self,
+        query: String,
+        at: Option<BH>,
+    ) -> Result<ProofPlanResponse<BH>, CommitmentsApiError>;
+
+    /// Returns evm proof plan for the given query text (verifiable in the evm).
+    #[method(name = "commitments_v1_evmProofPlan", blocking)]
+    fn v1_evm_proof_plan(
+        &self,
+        query: String,
+        at: Option<BH>,
+    ) -> Result<ProofPlanResponse<BH>, CommitmentsApiError>;
 }

--- a/rpc/src/commitments/error.rs
+++ b/rpc/src/commitments/error.rs
@@ -1,9 +1,10 @@
 use attestation_tree::{AttestationTreeError, AttestationTreeProofError};
 use jsonrpsee::types::ErrorObjectOwned;
+use proof_of_sql_planner::PlannerError;
 use snafu::Snafu;
 use sxt_core::tables::TableIdentifierConversionError;
 
-use crate::commitments::limits::{NUM_TABLES_LIMIT, PROOF_PLAN_SIZE_LIMIT};
+use crate::commitments::limits::{NUM_TABLES_LIMIT, PROOF_PLAN_SIZE_LIMIT, QUERY_SIZE_LIMIT};
 
 /// The base error code used by the commitments RPCs.
 const BASE_ERROR: i32 = 254000;
@@ -15,10 +16,16 @@ pub enum CommitmentsApiError {
     #[snafu(display(
         "proof plan of size {proof_plan_size} exceeds limit {PROOF_PLAN_SIZE_LIMIT}"
     ))]
-    ProofPlanSizeLimit { proof_plan_size: usize },
+    ProofPlanSizeLimit {
+        /// The actual proof plan size.
+        proof_plan_size: usize,
+    },
     /// Failed to deserialize proof plan.
-    #[snafu(display("failed to deserialize proof plan: {source}"), context(false))]
-    DeserializeProofPlan { source: bincode::error::DecodeError },
+    #[snafu(display("failed to deserialize proof plan: {source}"))]
+    DeserializeProofPlan {
+        /// The source bincode error.
+        source: bincode::error::DecodeError,
+    },
     /// Failed to convert table identifier from proof-of-sql to sxt-chain type.
     #[snafu(
         display(
@@ -27,23 +34,36 @@ pub enum CommitmentsApiError {
         context(false)
     )]
     TableIdentifierConversion {
+        /// The source conversion error.
         source: TableIdentifierConversionError,
     },
     /// Number of tables exceeds limit.
     #[snafu(display("query against {num_tables} tables exceeds limit of {NUM_TABLES_LIMIT}"))]
-    NumTablesLimit { num_tables: usize },
+    NumTablesLimit {
+        /// The actual table count.
+        num_tables: usize,
+    },
     /// Failed to query storage.
     #[snafu(display("failed to query storage: {source}"), context(false))]
-    Storage { source: sp_blockchain::Error },
+    Storage {
+        /// The source substrate error.
+        source: sp_blockchain::Error,
+    },
     /// Commitment does not exist in storage.
     #[snafu(display("commitment does not exist in storage"))]
     NoSuchCommitment,
     /// Failed to decode commitment in storage.
     #[snafu(display("failed to decode commitment in storage"), context(false))]
-    CommitmentDecode { source: codec::Error },
+    CommitmentDecode {
+        /// The source codec error.
+        source: codec::Error,
+    },
     /// Failed to create attestation tree.
     #[snafu(display("failed to create attestation tree: {source}"), context(false))]
-    AttestationTree { source: AttestationTreeError },
+    AttestationTree {
+        /// The source attestation tree error.
+        source: AttestationTreeError,
+    },
     /// Failed to generate merkle proof for commitments.
     #[snafu(
         display("failed to generate merkle proof for commitment: {source}"),
@@ -53,6 +73,71 @@ pub enum CommitmentsApiError {
     /// Staking contract info is not defined in storage.
     #[snafu(display("staking contract info is not defined in storage"))]
     NoStakingContract,
+    /// Query size exceeds limit.
+    #[snafu(display("query size {query_size} exceeds limit {QUERY_SIZE_LIMIT}"))]
+    QuerySizeLimit {
+        /// The actual query size.
+        query_size: usize,
+    },
+    /// Failed to parse query.
+    #[snafu(display("failed to parse query: {source}"), context(false))]
+    QueryParse {
+        /// The source parser error.
+        source: sqlparser::parser::ParserError,
+    },
+    /// Expected exactly one sql statement in query input.
+    #[snafu(display("expected exactly one sql statement in query input, found {num_statements}"))]
+    NotOneStatement {
+        /// The actual number of statements
+        num_statements: usize,
+    },
+    /// Encountered proof-of-sql incompatible relation.
+    #[snafu(
+        display("encountered proof-of-sql incompatible relation: {source}"),
+        context(false)
+    )]
+    ProofOfSqlIncompatibleRelation {
+        /// The source proof-of-sql error.
+        source: proof_of_sql::base::database::ParseError,
+    },
+    /// Received error from runtime api.
+    #[snafu(display("received error from runtime api: {source}"), context(false))]
+    RuntimeApi {
+        /// The source runtime api error.
+        source: sp_api::ApiError,
+    },
+    /// Unexpected table to commitment mismap.
+    #[snafu(display("unexpected table ref to commitment mismap, statement has {num_tables} tables but runtime api returned {num_commitments} commitments"))]
+    UnexpectedTableCommitmentMismap {
+        num_tables: usize,
+        num_commitments: usize,
+    },
+    /// Failed to deserialize table commitment.
+    #[snafu(display("failed to deserialize table commitment: {source}"))]
+    DeserializeTableCommitment {
+        /// The source bincode error.
+        source: bincode::error::DecodeError,
+    },
+    /// Encountered error in proof-of-sql planner.
+    #[snafu(
+        display("encountered error in proof-of-sql planner: {source}"),
+        context(false)
+    )]
+    Planner {
+        /// The osource planner error.
+        source: PlannerError,
+    },
+    /// Tables do not exist or have incomplete commitment coverage for all schemes.
+    #[snafu(display(
+        "tables do not exist or have incomplete commitment coverage for all schemes"
+    ))]
+    IncompleteCommitmentCoverage,
+    /// Failed to encode proof plan.
+    #[snafu(display("failed to encode proof plan: {source}"), context(false))]
+    EncodeProofPlan {
+        /// The source bincode error.
+        source: bincode::error::EncodeError,
+    },
 }
 
 impl From<CommitmentsApiError> for ErrorObjectOwned {
@@ -70,6 +155,16 @@ impl From<CommitmentsApiError> for ErrorObjectOwned {
                 CommitmentsApiError::AttestationTree { .. } => 7,
                 CommitmentsApiError::AttestationTreeProof { .. } => 8,
                 CommitmentsApiError::NoStakingContract => 9,
+                CommitmentsApiError::QuerySizeLimit { .. } => 10,
+                CommitmentsApiError::QueryParse { .. } => 11,
+                CommitmentsApiError::NotOneStatement { .. } => 12,
+                CommitmentsApiError::ProofOfSqlIncompatibleRelation { .. } => 13,
+                CommitmentsApiError::RuntimeApi { .. } => 14,
+                CommitmentsApiError::UnexpectedTableCommitmentMismap { .. } => 15,
+                CommitmentsApiError::DeserializeTableCommitment { .. } => 16,
+                CommitmentsApiError::Planner { .. } => 17,
+                CommitmentsApiError::IncompleteCommitmentCoverage => 18,
+                CommitmentsApiError::EncodeProofPlan { .. } => 19,
             };
 
         ErrorObjectOwned::owned(code, message, None::<()>)

--- a/rpc/src/commitments/limits.rs
+++ b/rpc/src/commitments/limits.rs
@@ -3,3 +3,18 @@ pub const PROOF_PLAN_SIZE_LIMIT: usize = 65_536;
 
 /// Input limit for number of tables in queries.
 pub const NUM_TABLES_LIMIT: usize = 64;
+
+/// Input limit for sql query text.
+pub const QUERY_SIZE_LIMIT: usize = 65_536;
+
+#[cfg(test)]
+mod tests {
+    use sxt_runtime::pallet_commitments::runtime_api::MAX_TABLES_IN_TABLE_COMMITMENTS_QUERY;
+
+    use super::*;
+
+    #[test]
+    fn num_tables_limit_does_not_exceed_table_commitments_api_limit() {
+        assert!(NUM_TABLES_LIMIT as u32 <= MAX_TABLES_IN_TABLE_COMMITMENTS_QUERY);
+    }
+}

--- a/rpc/src/commitments/mod.rs
+++ b/rpc/src/commitments/mod.rs
@@ -7,3 +7,7 @@ pub use api::CommitmentsApiServer;
 
 mod api_impl;
 pub use api_impl::CommitmentsApiImpl;
+
+mod proof_plan_for_query_and_commitments;
+
+mod statement_and_associated_table_refs;

--- a/rpc/src/commitments/proof_plan_for_query_and_commitments.rs
+++ b/rpc/src/commitments/proof_plan_for_query_and_commitments.rs
@@ -1,0 +1,323 @@
+use datafusion::config::{ConfigOptions, SqlParserOptions};
+use proof_of_sql::base::commitment::{QueryCommitments, TableCommitment};
+use proof_of_sql::sql::proof_plans::DynProofPlan;
+use proof_of_sql_commitment_map::generic_over_commitment::ConcreteType;
+use proof_of_sql_commitment_map::{CommitmentId, GenericOverCommitmentFn, TableCommitmentBytes};
+use proof_of_sql_planner::sql_to_proof_plans;
+
+use super::error::CommitmentsApiError;
+use super::statement_and_associated_table_refs::StatementAndAssociatedTableRefs;
+
+/// Since all of our table identifiers/column identifiers are stored and communicated in all-caps,
+/// we need to disable this datafusion setting that will coerce identifiers to lowercase.
+fn datafusion_config_no_normalization() -> ConfigOptions {
+    let mut config = ConfigOptions::new();
+    config.sql_parser = SqlParserOptions {
+        enable_ident_normalization: false,
+        ..Default::default()
+    };
+    config
+}
+
+fn proof_plan_for_query_and_commitments<C: CommitmentId>(
+    statement: StatementAndAssociatedTableRefs,
+    table_commitments: &[TableCommitmentBytes],
+) -> Result<DynProofPlan, CommitmentsApiError> {
+    let num_tables = statement.table_refs().len();
+    let num_commitments = table_commitments.len();
+    if num_tables != num_commitments {
+        return Err(CommitmentsApiError::UnexpectedTableCommitmentMismap {
+            num_tables,
+            num_commitments,
+        });
+    }
+
+    let table_commitments_typed = table_commitments
+        .iter()
+        .map(TableCommitment::<C>::try_from)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|source| CommitmentsApiError::DeserializeTableCommitment { source })?;
+
+    let query_commitments: QueryCommitments<C> = statement
+        .table_refs()
+        .iter()
+        .cloned()
+        .zip(table_commitments_typed)
+        .collect();
+
+    let proof_plan = sql_to_proof_plans(
+        std::slice::from_ref(statement.statement()),
+        &query_commitments,
+        &datafusion_config_no_normalization(),
+    )?
+    .pop()
+    .expect("expected one proof plan for one statement");
+
+    Ok(proof_plan)
+}
+
+/// `GenericOverCommitmentFn` that returns a `DynProofPlan` for the given query and commitments.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProofPlanForQueryAndCommitments(pub StatementAndAssociatedTableRefs);
+
+impl GenericOverCommitmentFn for ProofPlanForQueryAndCommitments {
+    type In = ConcreteType<Vec<TableCommitmentBytes>>;
+    type Out = ConcreteType<Result<DynProofPlan, CommitmentsApiError>>;
+
+    fn call<C: CommitmentId>(
+        &self,
+        input: Vec<TableCommitmentBytes>,
+    ) -> Result<DynProofPlan, CommitmentsApiError> {
+        proof_plan_for_query_and_commitments::<C>(self.0.clone(), &input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fmt::Debug;
+    use std::marker::PhantomData;
+
+    use commitment_sql::OnChainTableToTableCommitmentFn;
+    use indexmap::IndexMap;
+    use itertools::Itertools;
+    use on_chain_table::{OnChainColumn, OnChainTable};
+    use proof_of_sql::base::database::{ColumnType, TableRef, TestSchemaAccessor};
+    use proof_of_sql_commitment_map::generic_over_commitment::{
+        GenericOverCommitment,
+        PairType,
+        ResultOkType,
+        TableCommitmentType,
+    };
+    use proof_of_sql_commitment_map::{AnyCommitmentScheme, PerCommitmentScheme};
+    use proof_of_sql_static_setups::io::get_or_init_from_files_with_four_points_unchecked;
+    use sqlparser::ast::Ident;
+    use sqlparser::dialect::GenericDialect;
+    use sqlparser::parser::Parser;
+
+    use super::*;
+
+    struct UnwrapResultFn<O, E>(PhantomData<(O, E)>);
+
+    impl<O, E> GenericOverCommitmentFn for UnwrapResultFn<O, E>
+    where
+        O: GenericOverCommitment,
+        E: Debug,
+    {
+        type In = ResultOkType<O, E>;
+        type Out = O;
+
+        fn call<C: CommitmentId>(
+            &self,
+            input: <Self::In as GenericOverCommitment>::WithCommitment<C>,
+        ) -> <Self::Out as GenericOverCommitment>::WithCommitment<C> {
+            input.unwrap()
+        }
+    }
+
+    struct TableCommitmentToBytesFn;
+
+    impl GenericOverCommitmentFn for TableCommitmentToBytesFn {
+        type In = TableCommitmentType;
+        type Out = ConcreteType<TableCommitmentBytes>;
+
+        fn call<C: CommitmentId>(&self, input: TableCommitment<C>) -> TableCommitmentBytes {
+            TableCommitmentBytes::try_from(&input).unwrap()
+        }
+    }
+
+    struct ListConcretePairFn<T>(PhantomData<T>);
+
+    impl<T> GenericOverCommitmentFn for ListConcretePairFn<T> {
+        type In = PairType<ConcreteType<T>, ConcreteType<T>>;
+        type Out = ConcreteType<Vec<T>>;
+
+        fn call<C: CommitmentId>(
+            &self,
+            input: <Self::In as GenericOverCommitment>::WithCommitment<C>,
+        ) -> <Self::Out as GenericOverCommitment>::WithCommitment<C> {
+            vec![input.0, input.1]
+        }
+    }
+
+    fn valid_statement_and_commitments() -> (
+        StatementAndAssociatedTableRefs,
+        PerCommitmentScheme<ConcreteType<Vec<TableCommitmentBytes>>>,
+        DynProofPlan,
+    ) {
+        let setups = get_or_init_from_files_with_four_points_unchecked();
+
+        let table_1_id: TableRef = "NAMESPACE.TABLE1".parse().unwrap();
+        let int_col_id = Ident::new("INT_COL");
+        let table1_col_id: Ident = Ident::new("TABLE1_COL");
+        let table_1_data = OnChainTable::try_from_iter([
+            (int_col_id.clone(), OnChainColumn::Int(vec![1, 2])),
+            (
+                table1_col_id.clone(),
+                OnChainColumn::VarChar(["lorem", "ipsum"].map(String::from).to_vec()),
+            ),
+        ])
+        .unwrap();
+        let table_1_commitments = setups
+            .map(OnChainTableToTableCommitmentFn::new(&table_1_data, 0))
+            .map(UnwrapResultFn(PhantomData));
+        let table_1_commitment_bytes = table_1_commitments.map(TableCommitmentToBytesFn);
+
+        let table_2_id: TableRef = "NAMESPACE.TABLE2".parse().unwrap();
+        let table2_col_id: Ident = Ident::new("TABLE2_COL");
+        let table_2_data = OnChainTable::try_from_iter([
+            (int_col_id.clone(), OnChainColumn::Int(vec![1, 2])),
+            (
+                table2_col_id.clone(),
+                OnChainColumn::VarChar(["dolor", "sit"].map(String::from).to_vec()),
+            ),
+        ])
+        .unwrap();
+        let table_2_commitments = setups
+            .map(OnChainTableToTableCommitmentFn::new(&table_2_data, 0))
+            .map(UnwrapResultFn(PhantomData));
+        let table_2_commitment_bytes = table_2_commitments.map(TableCommitmentToBytesFn);
+
+        let table_commitment_lists_per_commitment_scheme = table_1_commitment_bytes
+            .zip(table_2_commitment_bytes)
+            .map(ListConcretePairFn(PhantomData));
+
+        let sql_text = format!("SELECT * FROM {table_1_id} JOIN {table_2_id} ON {table_1_id}.{int_col_id} = {table_2_id}.{int_col_id}");
+        let statement = Parser::parse_sql(&GenericDialect {}, &sql_text)
+            .unwrap()
+            .pop()
+            .unwrap();
+
+        let statement_and_associated_table_refs =
+            StatementAndAssociatedTableRefs::try_from(statement.clone()).unwrap();
+
+        let expected_schema_accessor = TestSchemaAccessor::new(IndexMap::from_iter([
+            (
+                table_1_id,
+                IndexMap::from_iter([
+                    (int_col_id.clone(), ColumnType::Int),
+                    (table1_col_id, ColumnType::VarChar),
+                ]),
+            ),
+            (
+                table_2_id,
+                IndexMap::from_iter([
+                    (int_col_id, ColumnType::Int),
+                    (table2_col_id, ColumnType::VarChar),
+                ]),
+            ),
+        ]));
+
+        let expected_proof_plan = sql_to_proof_plans(
+            &[statement],
+            &expected_schema_accessor,
+            &datafusion_config_no_normalization(),
+        )
+        .unwrap()
+        .pop()
+        .unwrap();
+
+        (
+            statement_and_associated_table_refs,
+            table_commitment_lists_per_commitment_scheme,
+            expected_proof_plan,
+        )
+    }
+
+    #[test]
+    fn we_can_construct_proof_plan_for_query_and_commitments() {
+        let (
+            statement_and_associated_table_refs,
+            table_commitment_lists_per_commitment_scheme,
+            expected_proof_plan,
+        ) = valid_statement_and_commitments();
+
+        let proof_plan = table_commitment_lists_per_commitment_scheme
+            .map(ProofPlanForQueryAndCommitments(
+                statement_and_associated_table_refs,
+            ))
+            .into_iter()
+            .map(|any| any.unwrap().unwrap())
+            .all_equal_value()
+            .expect("all commitment schemes should have the same result");
+
+        assert_eq!(proof_plan, expected_proof_plan);
+    }
+
+    #[test]
+    fn we_cannot_construct_proof_plan_with_table_commitments_mismap() {
+        let (_, table_commitment_lists_per_commitment_scheme, _) =
+            valid_statement_and_commitments();
+
+        let statement_with_only_one_table = StatementAndAssociatedTableRefs::try_from(
+            Parser::parse_sql(&GenericDialect {}, "SELECT * FROM NAMESPACE.TABLE1")
+                .unwrap()
+                .pop()
+                .unwrap(),
+        )
+        .unwrap();
+
+        table_commitment_lists_per_commitment_scheme
+            .map(ProofPlanForQueryAndCommitments(
+                statement_with_only_one_table,
+            ))
+            .into_iter()
+            .for_each(|any_result| {
+                assert!(matches!(
+                    any_result.unwrap(),
+                    Err(CommitmentsApiError::UnexpectedTableCommitmentMismap { .. })
+                ));
+            })
+    }
+
+    #[test]
+    fn we_cannot_construct_proof_plan_with_invalid_table_commitments() {
+        let (statement_and_associated_table_refs, _, _) = valid_statement_and_commitments();
+
+        let bad_commitment = TableCommitmentBytes {
+            data: vec![].try_into().unwrap(),
+        };
+
+        let bad_commitments =
+            AnyCommitmentScheme::HyperKzg(vec![bad_commitment.clone(), bad_commitment]);
+
+        let result = bad_commitments
+            .map(ProofPlanForQueryAndCommitments(
+                statement_and_associated_table_refs,
+            ))
+            .unwrap();
+
+        assert!(matches!(
+            result,
+            Err(CommitmentsApiError::DeserializeTableCommitment { .. })
+        ));
+    }
+
+    #[test]
+    fn we_cannot_construct_proof_plan_with_nonexistent_column() {
+        let (_, table_commitment_lists_per_commitment_scheme, _) =
+            valid_statement_and_commitments();
+
+        let statement_with_only_one_table = StatementAndAssociatedTableRefs::try_from(
+            Parser::parse_sql(
+                &GenericDialect {},
+                "SELECT NONEXISTENT_COLUMN FROM NAMESPACE.TABLE1 JOIN NAMESPACE.TABLE2 ON NAMESPACE.TABLE1.INT_COL = NAMESPACE.TABLE2.INT_COL",
+            )
+            .unwrap()
+            .pop()
+            .unwrap(),
+        )
+        .unwrap();
+
+        table_commitment_lists_per_commitment_scheme
+            .map(ProofPlanForQueryAndCommitments(
+                statement_with_only_one_table,
+            ))
+            .into_iter()
+            .for_each(|any_result| {
+                assert!(matches!(
+                    any_result.unwrap(),
+                    Err(CommitmentsApiError::Planner { .. })
+                ));
+            })
+    }
+}

--- a/rpc/src/commitments/statement_and_associated_table_refs.rs
+++ b/rpc/src/commitments/statement_and_associated_table_refs.rs
@@ -1,0 +1,71 @@
+use indexmap::IndexSet;
+use proof_of_sql::base::database::{ParseError, TableRef};
+use proof_of_sql_planner::get_table_refs_from_statement;
+use sqlparser::ast::Statement;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+/// A sqlparser `Statement` and all of its relations as proof-of-sql `TableRef`s.
+pub struct StatementAndAssociatedTableRefs {
+    statement: Statement,
+    table_refs: IndexSet<TableRef>,
+}
+
+impl TryFrom<Statement> for StatementAndAssociatedTableRefs {
+    type Error = ParseError;
+
+    fn try_from(statement: Statement) -> Result<Self, Self::Error> {
+        let table_refs = get_table_refs_from_statement(&statement)?;
+
+        Ok(StatementAndAssociatedTableRefs {
+            statement,
+            table_refs,
+        })
+    }
+}
+
+impl StatementAndAssociatedTableRefs {
+    /// Returns the stored sqlparser statement.
+    pub fn statement(&self) -> &Statement {
+        &self.statement
+    }
+
+    /// Returns the stored table refs.
+    pub fn table_refs(&self) -> &IndexSet<TableRef> {
+        &self.table_refs
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use sqlparser::dialect::GenericDialect;
+    use sqlparser::parser::Parser;
+
+    use super::*;
+
+    #[test]
+    fn we_can_construct_statement_and_associated_table_refs_from_statement() {
+        let sql_text =
+            "SELECT * FROM NAMESPACE.TABLE1 JOIN NAMESPACE.TABLE2 ON TABLE1.COL = TABLE2.COL";
+        let statement = Parser::parse_sql(&GenericDialect {}, sql_text)
+            .unwrap()
+            .pop()
+            .unwrap();
+
+        let statement_and_associated_table_refs =
+            StatementAndAssociatedTableRefs::try_from(statement.clone()).unwrap();
+
+        assert_eq!(statement_and_associated_table_refs.statement(), &statement);
+
+        let expected_table_refs = ["NAMESPACE.TABLE1", "NAMESPACE.TABLE2"]
+            .map(TableRef::from_str)
+            .map(Result::unwrap)
+            .into_iter()
+            .collect::<IndexSet<_>>();
+        assert_eq!(
+            statement_and_associated_table_refs.table_refs(),
+            &expected_table_refs
+        );
+    }
+}

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -100,6 +100,7 @@ where
     C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
     C::Api: BabeApi<Block>,
     C::Api: BlockBuilder<Block>,
+    C::Api: sxt_runtime::pallet_commitments::runtime_api::CommitmentsApi<Block>,
     P: TransactionPool + 'static,
     SC: SelectChain<Block> + 'static,
     B: sc_client_api::Backend<Block> + Send + Sync + 'static,

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -79,6 +79,8 @@ sp-arithmetic.workspace = true
 sp-statement-store.workspace =true
 pallet-statement.workspace = true
 sp-authority-discovery.workspace = true
+proof-of-sql-commitment-map.workspace = true
+sxt-core.workspace = true
 
 [build-dependencies]
 substrate-wasm-builder = { optional = true, workspace = true, default-features = true }
@@ -152,6 +154,8 @@ std = [
 	"sp-transaction-pool/std",
 	"sp-version/std",
 	"substrate-wasm-builder",
+	"proof-of-sql-commitment-map/std",
+	"sxt-core/std",
 ]
 
 runtime-benchmarks = [

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -42,6 +42,8 @@ use pallet_grandpa::AuthorityId as GrandpaId;
 pub use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
 pub use pallet_timestamp::Call as TimestampCall;
 use pallet_transaction_payment::{CurrencyAdapter, Multiplier};
+use proof_of_sql_commitment_map::generic_over_commitment::ConcreteType;
+use proof_of_sql_commitment_map::{AnyCommitmentScheme, TableCommitmentBytes};
 use sp_api::impl_runtime_apis;
 use sp_arithmetic::traits::UniqueSaturatedInto;
 use sp_authority_discovery::AuthorityId as AuthorityDiscoveryId;
@@ -1264,4 +1266,9 @@ impl_runtime_apis! {
         }
     }
 
+    impl pallet_commitments::runtime_api::CommitmentsApi<Block> for Runtime {
+        fn table_commitments_any_scheme(table_identifiers: pallet_commitments::runtime_api::CommitmentsApiBoundedTableIdentifiersList) -> Option<pallet_commitments::AnyTableCommitments> {
+            Commitments::table_commitments_any_scheme(table_identifiers.as_slice())
+        }
+    }
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -161,7 +161,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 224,
+    spec_version: 225,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
# Rationale for this change

A barrier to usage of proof-of-sql against chain data is the creation of proof-of-sql proof plans. Proof plans are similar to normal sql logical plans, but they are specifically for proof-of-sql proving/verification. The input for creating a proof plan, at a high level, is query text and schema information for all tables in a query.

The chain has proof-of-sql schema information for tables inside queries, so it makes sense to provide proof plan APIs on the chain itself. This change adds a couple RPC calls for this - proofPlan and evmProofPlan. The former supports more queries while the latter can be verified in the evm.

As much of this logic as possible has been implemented in a stateless way, and all state is accessed via runtime APIs.

# What changes are included in this PR?
- **feat: add CommitmentId extension trait for commitments**
- **feat: add CommitmentScheme::into_any_concrete method**
- **feat: read commitments storage for multiple tables and any scheme**
- **feat: add runtime api for reading commitments storage for any scheme**
- **feat: add proof plan RPCs**
- **chore: increment runtime impl_version after proof-plan-related changes**

# Are these changes tested?
Yes.
