### PR TITLE
feat: added extrinsics for updating UUIDs on namespaces and tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11986,7 +11986,6 @@ dependencies = [
 name = "pallet-tables"
 version = "0.1.0"
 dependencies = [
- "bincode 2.0.0",
  "commitment-sql",
  "frame-benchmarking",
  "frame-support",
@@ -11995,6 +11994,8 @@ dependencies = [
  "pallet-permissions",
  "parity-scale-codec",
  "proof-of-sql-commitment-map",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "scale-info",
  "sp-core",
  "sp-io",
@@ -19317,6 +19318,8 @@ dependencies = [
  "postcard",
  "proof-of-sql",
  "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "regex",
  "sc-client-api",
  "scale-info",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12000,6 +12000,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
+ "sqlparser",
  "sxt-core",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11994,8 +11994,6 @@ dependencies = [
  "pallet-permissions",
  "parity-scale-codec",
  "proof-of-sql-commitment-map",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
  "scale-info",
  "sp-core",
  "sp-io",

--- a/pallets/tables/Cargo.toml
+++ b/pallets/tables/Cargo.toml
@@ -30,8 +30,6 @@ sp-runtime = {default-features = false, workspace = true}
 sp-core.workspace = true
 pallet-commitments.workspace = true
 proof-of-sql-commitment-map.workspace = true
-rand_core.workspace = true
-rand_chacha.workspace = true
 
 [dev-dependencies]
 sp-core = { default-features = true, workspace = true }
@@ -47,8 +45,6 @@ std = [
 	"frame-system/std",
 	"scale-info/std",
 	"pallet-commitments/std",
-	"rand_chacha/std",
-	"rand_core/std"
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",

--- a/pallets/tables/Cargo.toml
+++ b/pallets/tables/Cargo.toml
@@ -13,6 +13,7 @@ publish = false
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
+sqlparser = { workspace = true, default-features = false }
 codec = { features = [
 	"derive",
 ], workspace = true }

--- a/pallets/tables/Cargo.toml
+++ b/pallets/tables/Cargo.toml
@@ -29,7 +29,8 @@ sp-runtime = {default-features = false, workspace = true}
 sp-core.workspace = true
 pallet-commitments.workspace = true
 proof-of-sql-commitment-map.workspace = true
-bincode = { workspace = true, features = ["serde", "alloc"] }
+rand_core.workspace = true
+rand_chacha.workspace = true
 
 [dev-dependencies]
 sp-core = { default-features = true, workspace = true }
@@ -45,6 +46,8 @@ std = [
 	"frame-system/std",
 	"scale-info/std",
 	"pallet-commitments/std",
+	"rand_chacha/std",
+	"rand_core/std"
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",

--- a/pallets/tables/src/tests.rs
+++ b/pallets/tables/src/tests.rs
@@ -382,7 +382,7 @@ fn test_get_or_generate_uuids_for_table_generates_uuids_if_missing() {
 
         // Act
         let (table_uuid, column_uuids) =
-            Tables::get_or_generate_uuids_for_table2(statement, identifier)
+            Tables::get_or_generate_uuids_for_table(statement, identifier)
                 .expect("should return generated uuids");
 
         // Assert

--- a/pallets/tables/src/tests.rs
+++ b/pallets/tables/src/tests.rs
@@ -293,7 +293,7 @@ fn update_namespace_uuid_works() {
 
         // Grant permission
         let (who, signer) = user(1);
-        set_permission!(who, TablesPalletPermission::EditSchema);
+        set_permission!(who, TablesPalletPermission::EditUuid);
 
         // Call extrinsic
         assert_ok!(Tables::update_namespace_uuid(
@@ -341,7 +341,7 @@ fn update_table_uuid_works() {
 
         // Grant permission
         let (who, signer) = user(1);
-        set_permission!(who, TablesPalletPermission::EditSchema);
+        set_permission!(who, TablesPalletPermission::EditUuid);
 
         // Call extrinsic
         assert_ok!(Tables::update_table_uuid(

--- a/pallets/tables/src/weights.rs
+++ b/pallets/tables/src/weights.rs
@@ -54,6 +54,10 @@ pub trait WeightInfo {
 
 	/// drop a table
 	fn drop_table() -> Weight;
+	/// Weight for updating a namespace UUID
+	fn update_namespace_uuid() -> Weight;
+	/// Weight for updated a table UUID
+	fn update_table_uuid() -> Weight;
 }
 
 /// TODO: add docs
@@ -87,6 +91,14 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	fn drop_table() -> Weight {
 		Weight::from_parts(0,0)
 	}
+
+	fn update_namespace_uuid() -> Weight {
+		Weight::from_parts(0,0)
+	}
+
+	fn update_table_uuid() -> Weight {
+		Weight::from_parts(0,0)
+	}
 }
 
 // For backwards compatibility and tests
@@ -116,6 +128,12 @@ impl WeightInfo for () {
 	}
 
 	fn create_namespace() -> Weight {
+		Weight::from_parts(0,0)
+	}
+	fn update_namespace_uuid() -> Weight {
+		Weight::from_parts(0,0)
+	}
+	fn update_table_uuid() -> Weight {
 		Weight::from_parts(0,0)
 	}
 }

--- a/sxt-core/Cargo.toml
+++ b/sxt-core/Cargo.toml
@@ -42,6 +42,8 @@ hex = { workspace = true, default-features = false }
 alloy = { workspace = true, optional = true, features = ["full"]}
 serde_json = { workspace = true, default-features = false, features = ["alloc"] }
 regex = { workspace = true, default-features = false }
+rand_core = { workspace = true, default-features = false }
+rand_chacha = { workspace = true, default-features = false }
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/sxt-core/src/permissions.rs
+++ b/sxt-core/src/permissions.rs
@@ -57,10 +57,12 @@ pub enum PermissionLevel {
     Deserialize,
 )]
 pub enum TablesPalletPermission {
-    /// TODO: add docs
+    /// Permission related to editing table schemas
     EditSchema,
     /// TODO: add docs
     EditRewards,
+    /// Permission related to updating the UUIDs for tables or namespaces
+    EditUuid,
 }
 
 /// Permissions for pallet_governance TODO

--- a/sxt-core/src/tables.rs
+++ b/sxt-core/src/tables.rs
@@ -19,7 +19,7 @@ use sp_core::{blake2_256, RuntimeDebug, U256};
 use sp_runtime::DispatchError;
 use sp_runtime_interface::pass_by::PassByCodec;
 use sqlparser::ast::helpers::stmt_create_table::CreateTableBuilder;
-use sqlparser::ast::ObjectName;
+use sqlparser::ast::{Expr, ObjectName, SqlOption, Value};
 use sqlparser::dialect::PostgreSqlDialect;
 use sqlparser::parser::Parser;
 
@@ -475,6 +475,68 @@ fn strip_with_clause(sql: &str) -> (&str, Option<&str>) {
     }
 }
 
+/// Errors that can occure when updated a UUID in a SQL statement
+#[derive(Snafu, Debug)]
+pub enum UpdateUuidError {
+    /// The uuid supplied to inject was not valid utf8
+    InvalidUuid,
+    /// There was an error parsing the SQL statement into or from its object form
+    ParseError {
+        /// The parsing error
+        error: CreateStatementParseError,
+    },
+}
+
+/// Attempts to insert the provided UUID into the WITH clause of the provided create
+/// statement maintaining any other previously assigned options
+pub fn update_uuid_in_create_table_statement(
+    uuid: TableUuid,
+    column_uuids: ColumnUuidList,
+    statement: CreateStatement,
+) -> Result<CreateStatement, UpdateUuidError> {
+    let table: CreateTableBuilder = create_statement_to_sqlparser(statement)
+        .map_err(|error| UpdateUuidError::ParseError { error })?;
+
+    let table_uuid_str = from_utf8(uuid.as_slice()).map_err(|e| UpdateUuidError::InvalidUuid)?;
+
+    // Turn the UUID entries into SqlOption
+    let table_entry = SqlOption {
+        name: "TABLE_UUID".into(),
+        value: Expr::Value(Value::UnQuotedString(table_uuid_str.to_string())),
+    };
+
+    let mut entries: Vec<SqlOption> = column_uuids
+        .iter()
+        .filter_map(|entry| {
+            match (
+                from_utf8(entry.name.as_slice()),
+                from_utf8(entry.uuid.as_slice()),
+            ) {
+                (Ok(name), Ok(val)) => Some(SqlOption {
+                    name: name.into(),
+                    value: Expr::Value(Value::UnQuotedString(val.to_string())),
+                }),
+                (_, _) => None,
+            }
+        })
+        .chain(Some(table_entry))
+        .chain(table.clone().with_options)
+        .collect::<Vec<SqlOption>>();
+
+    // Dedup everything as uppercase to ensure case-insensitive handling
+    entries.sort_by(|a, b| {
+        a.name
+            .value
+            .to_uppercase()
+            .cmp(&b.name.value.to_uppercase())
+    });
+    entries.dedup_by(|a, b| a.name.value.to_uppercase() == b.name.value.to_uppercase());
+
+    let table = table.with_options(entries);
+
+    sqlparser_to_create_statement(table).map_err(|error| UpdateUuidError::ParseError { error })
+}
+
 /// Convert a sqlparser `CreateTableBuilder` to a [`CreateStatement`].
 pub fn sqlparser_to_create_statement(
     create_table: CreateTableBuilder,
@@ -681,6 +743,7 @@ pub fn generate_uuid(source: String) -> Option<TableUuid> {
 mod tests {
     use alloc::string::String;
     use alloc::{format, vec};
+    use core::fmt::Debug;
 
     use sqlparser::ast::helpers::stmt_create_table::CreateTableBuilder;
     use sqlparser::ast::{ColumnDef, DataType, Ident};
@@ -956,6 +1019,63 @@ mod tests {
         let output = convert_ignite_create_statement(test_val);
 
         assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn we_can_inject_uuids_into_sql_statements() {
+        let test_val = "CREATE TABLE SOUTH.BOOK( ID INT NOT NULL, NAME VARCHAR NOT NULL, PRIMARY KEY (ID, NAME) );";
+        let create_statement: CreateStatement =
+            BoundedVec::try_from(test_val.as_bytes().to_vec()).unwrap();
+        let test_uuid: TableUuid = BoundedVec::try_from("TESTUUID".as_bytes().to_vec()).unwrap();
+        let expoected_val = "";
+        let r = update_uuid_in_create_table_statement(
+            test_uuid,
+            ColumnUuidList::default(),
+            create_statement,
+        );
+        assert!(r.is_ok());
+
+        let result_statement = r.unwrap();
+        let expected = "CREATE TABLE SOUTH.BOOK (ID INT NOT NULL, NAME VARCHAR NOT NULL, PRIMARY KEY (ID, NAME)) WITH (TABLE_UUID = TESTUUID)";
+        assert_eq!(expected, from_utf8(&result_statement).unwrap());
+    }
+
+    #[test]
+    fn we_can_inject_uuids_into_sql_statements_while_preserving_other_options() {
+        let test_val = "CREATE TABLE SOUTH.BOOK( ID INT NOT NULL, NAME VARCHAR NOT NULL, PRIMARY KEY (ID, NAME) ) WITH (public_key=A1D9C617F01C9975117B3D605CD4F945853E263D6E52888EE6E3AF5CB0FA1026,access_type=public_read,immutable=true);";
+        let create_statement: CreateStatement =
+            BoundedVec::try_from(test_val.as_bytes().to_vec()).unwrap();
+        let test_uuid: TableUuid = BoundedVec::try_from("TESTUUID".as_bytes().to_vec()).unwrap();
+        let expoected_val = "";
+        let r = update_uuid_in_create_table_statement(
+            test_uuid,
+            ColumnUuidList::default(),
+            create_statement,
+        );
+        assert!(r.is_ok());
+
+        let result_statement = r.unwrap();
+        let expected = "CREATE TABLE SOUTH.BOOK (ID INT NOT NULL, NAME VARCHAR NOT NULL, PRIMARY KEY (ID, NAME)) WITH (access_type = public_read, immutable = true, public_key = A1D9C617F01C9975117B3D605CD4F945853E263D6E52888EE6E3AF5CB0FA1026, TABLE_UUID = TESTUUID)";
+        assert_eq!(expected, from_utf8(&result_statement).unwrap());
+    }
+
+    #[test]
+    fn we_can_inject_uuids_into_sql_statements_overriding_existing_uuids_if_present() {
+        let test_val = "CREATE TABLE SOUTH.BOOK( ID INT NOT NULL, NAME VARCHAR NOT NULL, PRIMARY KEY (ID, NAME) ) WITH (table_uuid=abc678, public_key=A1D9C617F01C9975117B3D605CD4F945853E263D6E52888EE6E3AF5CB0FA1026,access_type=public_read,immutable=true);";
+        let create_statement: CreateStatement =
+            BoundedVec::try_from(test_val.as_bytes().to_vec()).unwrap();
+        let test_uuid: TableUuid = BoundedVec::try_from("TESTUUID".as_bytes().to_vec()).unwrap();
+        let expoected_val = "";
+        let r = update_uuid_in_create_table_statement(
+            test_uuid,
+            ColumnUuidList::default(),
+            create_statement,
+        );
+        assert!(r.is_ok());
+
+        let result_statement = r.unwrap();
+        let expected = "CREATE TABLE SOUTH.BOOK (ID INT NOT NULL, NAME VARCHAR NOT NULL, PRIMARY KEY (ID, NAME)) WITH (access_type = public_read, immutable = true, public_key = A1D9C617F01C9975117B3D605CD4F945853E263D6E52888EE6E3AF5CB0FA1026, TABLE_UUID = TESTUUID)";
+        assert_eq!(expected, from_utf8(&result_statement).unwrap());
     }
 }
 


### PR DESCRIPTION
# Rationale for this change
There is not currently a method of updating the on-chain namespace UUID or table UUID in the event that they need to be modified. This PR introduces extrinsics to update the UUIDs for a specific schema version and adds corresponding events that detail the updates. 

In addition, this PR updates the logic used to generate new UUIDs to improve compatibility with other services.

# Are these changes tested?

Yes