### PR TITLE
feat: add pallet_migrations to runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19429,6 +19429,7 @@ dependencies = [
  "pallet-indexing",
  "pallet-indices",
  "pallet-keystore",
+ "pallet-migrations",
  "pallet-multisig",
  "pallet-offences",
  "pallet-permissions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,6 +144,7 @@ pallet-balances = { version = "39.0.0", default-features = false }
 pallet-grandpa = { version = "38.0.0", default-features = false }
 pallet-sudo = { version = "38.0.0", default-features = false }
 pallet-multisig = { version = "38.0.0", default-features = false }
+pallet-migrations = { version = "8.0.0", default-features = false }
 pallet-timestamp = { version = "37.0.0", default-features = false }
 pallet-transaction-payment-rpc-runtime-api = { version = "38.0.0", default-features = false }
 scale-info = { version = "2.11.1", default-features = false }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -30,6 +30,7 @@ pallet-balances.workspace = true
 pallet-grandpa.workspace = true
 pallet-sudo.workspace = true
 pallet-multisig.workspace = true
+pallet-migrations.workspace = true
 pallet-timestamp.workspace = true
 pallet-transaction-payment.workspace = true
 sp-api.workspace = true
@@ -123,6 +124,7 @@ std = [
 	"pallet-grandpa/std",
 	"pallet-sudo/std",
 	"pallet-multisig/std",
+	"pallet-migrations/std",
 	"pallet-timestamp/std",
 	"pallet-transaction-payment-rpc-runtime-api/std",
 	"pallet-transaction-payment/std",
@@ -173,6 +175,7 @@ runtime-benchmarks = [
 	"pallet-grandpa/runtime-benchmarks",
 	"pallet-sudo/runtime-benchmarks",
 	"pallet-multisig/runtime-benchmarks",
+	"pallet-migrations/runtime-benchmarks",
 	"pallet-timestamp/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 	"pallet-staking/runtime-benchmarks",
@@ -197,6 +200,7 @@ try-runtime = [
 	"pallet-grandpa/try-runtime",
 	"pallet-sudo/try-runtime",
 	"pallet-multisig/try-runtime",
+	"pallet-migrations/try-runtime",
 	"pallet-timestamp/try-runtime",
 	"pallet-transaction-payment/try-runtime",
 	"sp-runtime/try-runtime",

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -290,7 +290,7 @@ impl frame_system::Config for Runtime {
     type OnSetCode = ();
     type MaxConsumers = frame_support::traits::ConstU32<16>;
     type SingleBlockMigrations = ();
-    type MultiBlockMigrator = ();
+    type MultiBlockMigrator = MultiBlockMigrations;
     type PreInherents = ();
     type PostInherents = ();
     type PostTransactions = ();
@@ -326,6 +326,25 @@ impl pallet_statement::Config for Runtime {
     type MaxAllowedStatements = MaxAllowedStatements;
     type MinAllowedBytes = MinAllowedBytes;
     type MaxAllowedBytes = MaxAllowedBytes;
+}
+
+parameter_types! {
+    pub MbmServiceWeight: Weight = Perbill::from_percent(80) * BlockWeights::get().max_block;
+}
+
+impl pallet_migrations::Config for Runtime {
+    type RuntimeEvent = RuntimeEvent;
+    #[cfg(not(feature = "runtime-benchmarks"))]
+    type Migrations = Migrations;
+    // Benchmarks need mocked migrations to guarantee that they succeed.
+    #[cfg(feature = "runtime-benchmarks")]
+    type Migrations = pallet_migrations::mock_helpers::MockedMigrations;
+    type CursorMaxLen = ConstU32<65_536>;
+    type IdentifierMaxLen = ConstU32<256>;
+    type MigrationStatusHandler = ();
+    type FailedMigrationHandler = frame_support::migrations::FreezeChainOnFailedMigration;
+    type MaxServiceWeight = MbmServiceWeight;
+    type WeightInfo = pallet_migrations::weights::SubstrateWeight<Runtime>;
 }
 
 impl pallet_utility::Config for Runtime {
@@ -866,6 +885,9 @@ mod runtime {
     #[runtime::pallet_index(71)]
     pub type Statement = pallet_statement;
 
+    #[runtime::pallet_index(72)]
+    pub type MultiBlockMigrations = pallet_migrations;
+
     // Custom pallets start at index 100 to ensure room for future consensus work
     #[runtime::pallet_index(100)]
     pub type Permissions = pallet_permissions::Pallet<Runtime>;
@@ -941,6 +963,7 @@ mod benches {
         [pallet_staking, Staking]
         [pallet_sudo, Sudo]
         [pallet_multisig, Multisig]
+        [pallet_migrations, MultiBlockMigrations]
         [frame_system, SystemBench::<Runtime>]
         [pallet_timestamp, Timestamp]
         [pallet_utility, Utility]


### PR DESCRIPTION
# Rationale for this change
We need to incoroporate the polkadot migrations pallet into our runtime if we want to be able to perform multi-block storage migrations. This is especially relevant as we are entering a more stable development phase, and all breaking storage changes in the future will need to be handled via migrations.


# What changes are included in this PR?
pallet-migrations added to runtime

# Are these changes tested?
This change does not affect existing business logic, which should be verified by existing tests.
