### PR TITLE
feat: update commission to 10%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,14 @@ jobs:
       - if: contains(matrix.os, 'macos')
         uses: ./.github/actions/macos-dependencies
 
+      - name: install rustfmt
+        if: contains(matrix.os, 'macos')
+        run: rustup component add rustfmt
+
+      - name: install clippy
+        if: contains(matrix.os, 'macos')
+        run: rustup component add clippy
+
       - name: Run fmt
         run: cargo fmt --all --check -- --config imports_granularity=Module,group_imports=StdExternalCrate,imports_layout=HorizontalVertical
         timeout-minutes: 30

--- a/pallets/system_tables/src/messages.rs
+++ b/pallets/system_tables/src/messages.rs
@@ -21,7 +21,7 @@ pub fn handle_message<T: Config>(sender: T::AccountId, message_bytes: Vec<u8>) -
 
     // Set session keys
     let prefs = ValidatorPrefs {
-        commission: Perbill::from_percent(0), // 0 Commission here, because we calculate it at the end of the era
+        commission: Perbill::from_percent(10),
         blocked: false,
     };
 

--- a/pallets/system_tables/src/tests.rs
+++ b/pallets/system_tables/src/tests.rs
@@ -393,8 +393,6 @@ fn default_commission_is_10_percent() {
 
         // Check that the commission is 10%
         let prefs = pallet_staking::Pallet::<Test>::validators(&eth_sender);
-        assert_eq!(prefs.commission, Perbill::from_percent(10)); 
-
-
+        assert_eq!(prefs.commission, Perbill::from_percent(10));
     });
 }

--- a/pallets/system_tables/src/tests.rs
+++ b/pallets/system_tables/src/tests.rs
@@ -8,7 +8,7 @@ use on_chain_table::OnChainTable;
 use sp_core::crypto::AccountId32;
 use sp_core::U256;
 use sp_runtime::traits::StaticLookup;
-use sp_runtime::DispatchError;
+use sp_runtime::{DispatchError, Perbill};
 use sxt_core::sxt_chain_runtime::api::runtime_types::pallet_system_tables;
 use sxt_core::tables::TableIdentifier;
 use sxt_core::utils::{
@@ -356,5 +356,45 @@ fn nomination_parsed_from_ipc_record_batch_works() {
             pallet_staking::Nominators::<Test>::drain().any(|(nominator, _)| nominator == account);
 
         assert!(found, "Expected nominator not found in staking nominators");
+    });
+}
+
+#[test]
+fn default_commission_is_10_percent() {
+    new_test_ext().execute_with(|| {
+        let eth_sender = eth_address_to_substrate_account_id::<Test>(ETH_TEST_WALLET).unwrap();
+
+        // We have to bond an amount to establish the stash/controller accounts
+        let test_amount = 100;
+        let bonding = get_staked_message(ETH_TEST_WALLET, test_amount.into());
+        assert_ok!(crate::process_staking::<Test>(bonding));
+
+        // Now try to register
+        let first_nonce = U256::from(1);
+        let request = get_register_keys_message(ETH_TEST_WALLET, ALICE_SESSION_KEYS, first_nonce);
+        assert_ok!(crate::process_evm_message::<Test>(request.clone()));
+
+        // The last processed should be 1 now
+        assert_eq!(
+            crate::LastProcessedUserNonce::<Test>::get(&eth_sender),
+            Some(first_nonce)
+        );
+
+        assert_eq!(
+            pallet_staking::Pallet::<Test>::bonded(&eth_sender),
+            Some(eth_sender.clone())
+        );
+        assert_eq!(
+            pallet_staking::Pallet::<Test>::ledger(eth_sender.clone().into())
+                .unwrap()
+                .total,
+            test_amount
+        );
+
+        // Check that the commission is 10%
+        let prefs = pallet_staking::Pallet::<Test>::validators(&eth_sender);
+        assert_eq!(prefs.commission, Perbill::from_percent(10)); 
+
+
     });
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -165,7 +165,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 227,
+    spec_version: 228,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
# Purpose
- Previously when we were onboarding validators we were setting them to a default of 0% commission 
- We want to set this to be a minimum of 10% 
- We use a custom onboarding flow as part of pallet-system-tables which is where we are specifying the default commission 