### PR TITLE
feat: add eth-ecdsa as a 4th runtime signature type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5286,6 +5286,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "eth-ecdsa"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives 0.8.22",
+ "alloy-signer",
+ "alloy-signer-local",
+ "k256",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "snafu 0.8.5",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+]
+
+[[package]]
 name = "eth_merkle_tree"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18564,6 +18564,7 @@ dependencies = [
 name = "sxt-runtime"
 version = "0.1.0"
 dependencies = [
+ "eth-ecdsa",
  "frame-benchmarking",
  "frame-election-provider-support",
  "frame-executive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
     "canaries",
     "pallets/zkpay",
     "proof-of-sql/commitment-column-mapping",
+    "eth-ecdsa",
 ]
 exclude = [
     "utoipa",  
@@ -58,6 +59,7 @@ bincode = { version = "2.0.0", default-features = false }
 const_format = { version = "0.2.33", default-features = false }
 commitment-sql = { path = "./proof-of-sql/commitment-sql/", default-features = false }
 datafusion = { version = "38.0.0", default-features = false }
+eth-ecdsa = { path = "./eth-ecdsa", default-features = false }
 sxt-runtime = { path = "./runtime", default-features = false }
 pallet-rewards = { path = "./pallets/rewards", default-features = false }
 pallet-commitments = { path = "./pallets/commitments", default-features = false }
@@ -205,6 +207,9 @@ handlebars = { version = "5.1.2", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 spin = "0.9.8"
 alloy = { version = "0.11.0", default-features = false }
+alloy-primitives = { version = "0.8.22", default-features = false }
+alloy-signer = { version = "0.11.1", default-features = false }
+alloy-signer-local = { version = "0.11.1", default-features = false }
 glob = "0.3.1"
 eth_merkle_tree = { version = "=0.1.1", default-features = false }
 anyhow = { version = "1.0.95", default-features = false }

--- a/eth-ecdsa/Cargo.toml
+++ b/eth-ecdsa/Cargo.toml
@@ -1,0 +1,50 @@
+[package]
+name = "eth-ecdsa"
+version = "0.1.0"
+license.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+edition.workspace = true
+
+[dependencies]
+alloy-primitives = { workspace = true, features = ["k256"] }
+codec = { features = [
+	"derive",
+], workspace = true }
+k256 = { workspace = true }
+scale-info = { features = [
+	"derive",
+	"serde",
+], workspace = true }
+sp-core = { features = ["serde"], workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { features = ["serde"], workspace = true }
+serde = { workspace = true, optional = true }
+snafu = { workspace = true }
+
+[dev-dependencies]
+alloy-signer = { workspace = true }
+alloy-signer-local = { workspace = true }
+sp-runtime = { features = ["serde"], workspace = true }
+
+[features]
+serde = ["dep:serde"]
+std = [
+	"codec/std",
+	"scale-info/std",
+	"sp-core/std",
+	"sp-io/std",
+	"sp-runtime/std",
+]
+
+runtime-benchmarks = [
+	"sp-runtime/runtime-benchmarks",
+]
+
+try-runtime = [
+	"sp-runtime/try-runtime",
+]
+
+[lints]
+workspace = true

--- a/eth-ecdsa/README.md
+++ b/eth-ecdsa/README.md
@@ -1,0 +1,2 @@
+# `eth-ecdsa`
+A 4th signature type to polkadot runtimes: EthEcdsa. It is a normal ECDSA signature, but expects data to be signed as an ethereum signed message. Associates the public key with AccountId32s like `0x000000000000000000000000<eth address>`.

--- a/eth-ecdsa/src/lib.rs
+++ b/eth-ecdsa/src/lib.rs
@@ -1,0 +1,8 @@
+#![doc = include_str!("../README.md")]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+mod signature;
+pub use signature::{EthEcdsaSignature, EthEcdsaSigner};
+
+mod multi_signature;
+pub use multi_signature::MultiSignature;

--- a/eth-ecdsa/src/multi_signature.rs
+++ b/eth-ecdsa/src/multi_signature.rs
@@ -1,0 +1,169 @@
+use codec::{Decode, Encode, MaxEncodedLen};
+use scale_info::TypeInfo;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+use snafu::Snafu;
+use sp_core::{ecdsa, ed25519, sr25519, RuntimeDebug};
+use sp_runtime::traits::{IdentifyAccount, Lazy, Verify};
+use sp_runtime::AccountId32;
+
+use crate::{EthEcdsaSignature, EthEcdsaSigner};
+
+/// Signature verify that can work with any known signature types.
+///
+/// Implemented similarly to `sp_runtime::MultiSignature` but with an extra variant `EthEcdsa`.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Eq, PartialEq, Clone, Encode, Decode, MaxEncodedLen, RuntimeDebug, TypeInfo)]
+pub enum MultiSignature {
+    /// An Ed25519 signature.
+    Ed25519(ed25519::Signature),
+    /// An Sr25519 signature.
+    Sr25519(sr25519::Signature),
+    /// An ECDSA/SECP256k1 signature.
+    Ecdsa(ecdsa::Signature),
+    /// An Eth ecdsa signature of EIP-191 data.
+    EthEcdsa(EthEcdsaSignature),
+}
+
+/// Public key for any known crypto algorithm.
+///
+/// Implemented similarly to `sp_runtime::MultiSignature` but with an extra variant `EthEcdsa`.
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Encode, Decode, RuntimeDebug, TypeInfo)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum MultiSigner {
+    /// An Ed25519 identity.
+    Ed25519(ed25519::Public),
+    /// An Sr25519 identity.
+    Sr25519(sr25519::Public),
+    /// An SECP256k1/ECDSA identity (actually, the Blake2 hash of the compressed pub key).
+    Ecdsa(ecdsa::Public),
+    /// An Ethereum SECP256k1/ECDSA identity, with the ethereum account id prepended by 12 0-bytes.
+    EthEcdsa(EthEcdsaSigner),
+}
+
+/// Encountered EthEcdsa variant unexpectedly.
+#[derive(Debug, Snafu)]
+#[snafu(display("encountered EthEcdsa variant unexpectedly"))]
+pub struct EncounteredEthEcdsa;
+
+impl From<sp_runtime::MultiSignature> for MultiSignature {
+    fn from(value: sp_runtime::MultiSignature) -> Self {
+        match value {
+            sp_runtime::MultiSignature::Ed25519(signature) => MultiSignature::Ed25519(signature),
+            sp_runtime::MultiSignature::Sr25519(signature) => MultiSignature::Sr25519(signature),
+            sp_runtime::MultiSignature::Ecdsa(signature) => MultiSignature::Ecdsa(signature),
+        }
+    }
+}
+
+impl TryFrom<MultiSignature> for sp_runtime::MultiSignature {
+    type Error = EncounteredEthEcdsa;
+
+    fn try_from(value: MultiSignature) -> Result<Self, Self::Error> {
+        match value {
+            MultiSignature::Ed25519(signature) => {
+                Ok(sp_runtime::MultiSignature::Ed25519(signature))
+            }
+            MultiSignature::Sr25519(signature) => {
+                Ok(sp_runtime::MultiSignature::Sr25519(signature))
+            }
+            MultiSignature::Ecdsa(signature) => Ok(sp_runtime::MultiSignature::Ecdsa(signature)),
+            MultiSignature::EthEcdsa(_) => Err(EncounteredEthEcdsa),
+        }
+    }
+}
+
+impl From<sp_runtime::MultiSigner> for MultiSigner {
+    fn from(value: sp_runtime::MultiSigner) -> Self {
+        match value {
+            sp_runtime::MultiSigner::Ed25519(signature) => MultiSigner::Ed25519(signature),
+            sp_runtime::MultiSigner::Sr25519(signature) => MultiSigner::Sr25519(signature),
+            sp_runtime::MultiSigner::Ecdsa(signature) => MultiSigner::Ecdsa(signature),
+        }
+    }
+}
+
+impl TryFrom<MultiSigner> for sp_runtime::MultiSigner {
+    type Error = EncounteredEthEcdsa;
+
+    fn try_from(value: MultiSigner) -> Result<Self, Self::Error> {
+        match value {
+            MultiSigner::Ed25519(signature) => Ok(sp_runtime::MultiSigner::Ed25519(signature)),
+            MultiSigner::Sr25519(signature) => Ok(sp_runtime::MultiSigner::Sr25519(signature)),
+            MultiSigner::Ecdsa(signature) => Ok(sp_runtime::MultiSigner::Ecdsa(signature)),
+            MultiSigner::EthEcdsa(_) => Err(EncounteredEthEcdsa),
+        }
+    }
+}
+
+impl IdentifyAccount for MultiSigner {
+    type AccountId = AccountId32;
+    fn into_account(self) -> AccountId32 {
+        match self {
+            MultiSigner::EthEcdsa(eth_ecdsa_signer) => eth_ecdsa_signer.into_account(),
+            sp_signer => sp_runtime::MultiSigner::try_from(sp_signer)
+                .expect("this is not eth-ecdsa")
+                .into_account(),
+        }
+    }
+}
+
+impl Verify for MultiSignature {
+    type Signer = MultiSigner;
+    fn verify<L: Lazy<[u8]>>(&self, msg: L, signer: &AccountId32) -> bool {
+        match self {
+            Self::EthEcdsa(eth_ecdsa_sig) => eth_ecdsa_sig.verify(msg, signer),
+            sp_signature => sp_runtime::MultiSignature::try_from(sp_signature.clone())
+                .expect("this is not eth-ecdsa")
+                .verify(msg, signer),
+        }
+    }
+}
+
+impl From<ed25519::Signature> for MultiSignature {
+    fn from(x: ed25519::Signature) -> Self {
+        sp_runtime::MultiSignature::from(x).into()
+    }
+}
+
+impl From<ed25519::Public> for MultiSigner {
+    fn from(x: ed25519::Public) -> Self {
+        sp_runtime::MultiSigner::from(x).into()
+    }
+}
+
+impl From<sr25519::Signature> for MultiSignature {
+    fn from(x: sr25519::Signature) -> Self {
+        sp_runtime::MultiSignature::from(x).into()
+    }
+}
+
+impl From<sr25519::Public> for MultiSigner {
+    fn from(x: sr25519::Public) -> Self {
+        sp_runtime::MultiSigner::from(x).into()
+    }
+}
+
+impl From<ecdsa::Signature> for MultiSignature {
+    fn from(x: ecdsa::Signature) -> Self {
+        sp_runtime::MultiSignature::from(x).into()
+    }
+}
+
+impl From<ecdsa::Public> for MultiSigner {
+    fn from(x: ecdsa::Public) -> Self {
+        sp_runtime::MultiSigner::from(x).into()
+    }
+}
+
+impl From<EthEcdsaSignature> for MultiSignature {
+    fn from(x: EthEcdsaSignature) -> Self {
+        MultiSignature::EthEcdsa(x)
+    }
+}
+
+impl From<EthEcdsaSigner> for MultiSigner {
+    fn from(x: EthEcdsaSigner) -> Self {
+        MultiSigner::EthEcdsa(x)
+    }
+}

--- a/eth-ecdsa/src/signature.rs
+++ b/eth-ecdsa/src/signature.rs
@@ -1,0 +1,122 @@
+use alloy_primitives::Address;
+use codec::{Decode, Encode, MaxEncodedLen};
+use k256::ecdsa::VerifyingKey;
+use scale_info::TypeInfo;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+use sp_core::{ecdsa, RuntimeDebug};
+use sp_runtime::traits::{IdentifyAccount, Lazy, Verify};
+use sp_runtime::AccountId32;
+
+/// Wrapper type over an ECDSA signature (a 512-bit value, plus 8 bits for recovery ID).
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Eq, PartialEq, Clone, Encode, Decode, MaxEncodedLen, RuntimeDebug, TypeInfo)]
+pub struct EthEcdsaSignature(pub ecdsa::Signature);
+
+/// Wrapper type over an ECDSA compressed public key.
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Encode, Decode, RuntimeDebug, TypeInfo)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct EthEcdsaSigner(pub ecdsa::Public);
+
+impl IdentifyAccount for EthEcdsaSigner {
+    type AccountId = AccountId32;
+    fn into_account(self) -> AccountId32 {
+        (*Address::from_public_key(
+            &VerifyingKey::from_sec1_bytes(&self.0)
+                .expect("ecdsa::Public key should be in compressed form"),
+        )
+        .into_word())
+        .into()
+    }
+}
+
+impl Verify for EthEcdsaSignature {
+    type Signer = EthEcdsaSigner;
+    fn verify<L: Lazy<[u8]>>(&self, mut msg: L, signer: &AccountId32) -> bool {
+        let Ok(alloy_sig) = alloy_primitives::PrimitiveSignature::from_raw_array(&self.0 .0) else {
+            return false;
+        };
+
+        let Ok(address) = alloy_sig.recover_address_from_msg(msg.get()) else {
+            return false;
+        };
+
+        &AccountId32::from(*address.into_word()) == signer
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_signer::SignerSync;
+    use alloy_signer_local::PrivateKeySigner;
+
+    use super::*;
+
+    #[test]
+    fn we_can_identify_account_id() {
+        let signer = PrivateKeySigner::random();
+
+        let verifying_key = signer.credential().verifying_key();
+
+        let eth_ecdsa_signer =
+            EthEcdsaSigner(ecdsa::Public::try_from(&verifying_key.to_sec1_bytes()[..]).unwrap());
+
+        let address = signer.address();
+
+        let expected_account_id = AccountId32::new(
+            core::iter::repeat(0)
+                .take(12)
+                .chain(address.into_array())
+                .collect::<Vec<_>>()
+                .try_into()
+                .unwrap(),
+        );
+
+        assert_eq!(eth_ecdsa_signer.into_account(), expected_account_id)
+    }
+
+    fn valid_verification_input() -> (EthEcdsaSignature, Vec<u8>, AccountId32) {
+        let signer = PrivateKeySigner::random();
+        let message = b"Hello World!";
+
+        let address = signer.address();
+
+        let account_id = AccountId32::new(
+            core::iter::repeat(0)
+                .take(12)
+                .chain(address.into_array())
+                .collect::<Vec<_>>()
+                .try_into()
+                .unwrap(),
+        );
+
+        let signature = signer.sign_message_sync(message).unwrap();
+
+        let eth_ecdsa_signature = EthEcdsaSignature(signature.as_bytes().into());
+
+        (eth_ecdsa_signature, message.to_vec(), account_id)
+    }
+
+    #[test]
+    fn we_can_verify_signature() {
+        let (eth_ecdsa_signature, message, account_id) = valid_verification_input();
+
+        assert!(eth_ecdsa_signature.verify(&message[..], &account_id));
+    }
+
+    #[test]
+    fn we_cannot_verify_signature_with_wrong_message() {
+        let (eth_ecdsa_signature, _, account_id) = valid_verification_input();
+
+        assert!(!eth_ecdsa_signature.verify(&b"Goodbye."[..], &account_id));
+    }
+
+    #[test]
+    fn we_cannot_verify_signature_with_wrong_account() {
+        let (eth_ecdsa_signature, message, mut account_id) = valid_verification_input();
+
+        let account_id_array = <sp_runtime::AccountId32 as AsMut<[u8]>>::as_mut(&mut account_id);
+        account_id_array[0] = account_id_array[0].wrapping_add(1);
+        assert!(!eth_ecdsa_signature.verify(&message[..], &account_id));
+    }
+}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -20,6 +20,7 @@ scale-info = { features = [
 	"derive",
 	"serde",
 ], workspace = true }
+eth-ecdsa = { workspace = true }
 frame-support = { features = ["experimental"], workspace = true }
 frame-system.workspace = true
 frame-try-runtime = { optional = true, workspace = true }
@@ -162,6 +163,7 @@ std = [
 	"substrate-wasm-builder",
 	"proof-of-sql-commitment-map/std",
 	"sxt-core/std",
+	"eth-ecdsa/std",
 ]
 
 runtime-benchmarks = [
@@ -190,6 +192,7 @@ runtime-benchmarks = [
 	"frame-election-provider-support/runtime-benchmarks",
 	"pallet-bags-list/runtime-benchmarks",
 	"pallet-utility/runtime-benchmarks",
+	"eth-ecdsa/runtime-benchmarks",
 ]
 
 try-runtime = [
@@ -219,6 +222,7 @@ try-runtime = [
 	"frame-election-provider-support/try-runtime",
 	"pallet-bags-list/try-runtime",
 	"pallet-utility/try-runtime",
+	"eth-ecdsa/try-runtime",
 ]
 
 [lints]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -112,7 +112,7 @@ pub use {
 pub type BlockNumber = u32;
 
 /// Alias to 512-bit hash when used in the context of a transaction signature on the chain.
-pub type Signature = MultiSignature;
+pub type Signature = eth_ecdsa::MultiSignature;
 
 /// Some way of identifying an account on the chain. We intentionally make it equivalent
 /// to the public key of our transaction signing scheme.


### PR DESCRIPTION
# Rationale for this change
While we can already sign transactions with ECDSA, the semantics of ECDSA signing are a bit different from ethereum. This change adds a new signature type for ECDSA signatures that are a bit more "ethereum compatible", as they expect payloads to be signed following EIP-191.

# What changes are included in this PR?
- **feat: add eth-ecdsa as a 4th runtime signature type**
- **feat: use eth_ecdsa MultiSignature in runtime**
- **feat: increment runtime spec_version to 232**

# Are these changes tested?
Yes.
