### PR TITLE
feat: track unstakes that have been claimed via system tables pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11437,6 +11437,7 @@ dependencies = [
  "proof-of-sql-static-setups",
  "scale-info",
  "serde_json",
+ "sp-api",
  "sp-authority-discovery",
  "sp-consensus-babe",
  "sp-core",

--- a/pallets/system_tables/Cargo.toml
+++ b/pallets/system_tables/Cargo.toml
@@ -40,6 +40,7 @@ hex.workspace = true
 serde_json = { workspace = true, default-features = false, features = ["alloc"] }
 log.workspace = true
 itertools.workspace = true
+sp-api.workspace = true
 
 [dev-dependencies]
 proof-of-sql-static-setups = { workspace = true, features = ["io"] }
@@ -93,6 +94,7 @@ std = [
 	"sp-authority-discovery/std",
 	"sp-consensus-babe/std",
 	"sp-staking/std",
+	"sp-api/std",
 ]
 
 runtime-benchmarks = [

--- a/pallets/system_tables/src/lib.rs
+++ b/pallets/system_tables/src/lib.rs
@@ -19,6 +19,8 @@ mod tests;
 mod messages;
 mod templates;
 
+pub mod runtime_api;
+
 #[allow(clippy::manual_inspect)]
 #[frame_support::pallet]
 pub mod pallet {
@@ -28,7 +30,7 @@ pub mod pallet {
     use frame_support::dispatch::{DispatchResult, RawOrigin};
     use frame_support::pallet_prelude::*;
     use frame_support::traits::StoredMap;
-    use frame_system::pallet_prelude::*;
+    use frame_system::pallet_prelude::{BlockNumberFor, *};
     use itertools::Itertools;
     use on_chain_table::OnChainTable;
     use pallet_session::historical::IdentificationTuple;
@@ -44,6 +46,7 @@ pub mod pallet {
         SystemRequest,
         SystemRequestType,
     };
+    use sxt_core::system_tables::ClaimedUnstake;
     use sxt_core::tables::{TableIdentifier, TableName, TableNamespace};
     use sxt_core::utils::eth_address_to_substrate_account_id;
 
@@ -124,6 +127,8 @@ pub mod pallet {
         AccountNotUnbonding,
         /// Occurs when attempting to claim locked funds
         FundsLocked,
+        /// Account was not claiming unstake.
+        NoSuchClaimedUnstake,
     }
 
     #[pallet::call]
@@ -154,6 +159,20 @@ pub mod pallet {
                 None => Ok(()),
                 Some(req) => process_request::<T>(req),
             }
+        }
+
+        /// Returns a list of all currently-processing claimed unstakes.
+        pub fn claimed_unstakes(
+        ) -> Vec<ClaimedUnstake<T::AccountId, BlockNumberFor<T>, T::CurrencyBalance>> {
+            ClaimedUnstakes::<T>::iter()
+                .map(
+                    |(staker, claim_block_number, claimed_amount)| ClaimedUnstake {
+                        staker,
+                        claim_block_number,
+                        claimed_amount,
+                    },
+                )
+                .collect()
         }
     }
 
@@ -310,6 +329,14 @@ pub mod pallet {
 
                         let stake_amount = amount.min(&U256::from(u128::MAX)).low_u128();
 
+                        let block_number_to_remove = ClaimedUnstakes::<T>::iter_prefix(&staker_id)
+                            .find_map(|(block_number, amount)| {
+                                (amount == stake_amount).then_some(block_number)
+                            })
+                            .ok_or(Error::<T>::NoSuchClaimedUnstake)?;
+
+                        ClaimedUnstakes::<T>::remove(&staker_id, block_number_to_remove);
+
                         Ok(())
                     }
                     _ => Err(Error::<T>::MissingExpectedField.into()),
@@ -333,9 +360,10 @@ pub mod pallet {
                             sxt_core::utils::eth_address_to_substrate_account_id::<T>(&staker)?;
 
                         // Make sure they're staked
-                        if pallet_staking::Ledger::<T>::get(&staker_id).is_none() {
+                        let Some(old_staking_ledger) = pallet_staking::Ledger::<T>::get(&staker_id)
+                        else {
                             return Err(Error::<T>::AccountNotStaked.into());
-                        }
+                        };
 
                         // Make sure they're in an unbonding state
                         if !(pallet_staking::Pallet::<T>::is_unbonding(&staker_id)?) {
@@ -353,7 +381,9 @@ pub mod pallet {
                             .map_err(|e| e.error)?;
 
                         // Check if the user still has entries in the staking ledger
-                        if let Some(ledger) = pallet_staking::Ledger::<T>::get(&staker_id) {
+                        let maybe_new_staking_ledger = pallet_staking::Ledger::<T>::get(&staker_id);
+
+                        if maybe_new_staking_ledger.is_some() {
                             // If this was a partial unlock we need to actually check if the locks
                             // were removed by the withdrawal call. If they weren't the claim is
                             // unsuccessful and we return an error. Otherwise we emit the event
@@ -362,6 +392,18 @@ pub mod pallet {
                                 return Err(Error::<T>::FundsLocked.into());
                             }
                         }
+
+                        let new_total = maybe_new_staking_ledger
+                            .map(|ledger| ledger.total)
+                            .unwrap_or(0);
+
+                        let amount_withdrawn = old_staking_ledger.total.saturating_sub(new_total);
+
+                        ClaimedUnstakes::<T>::insert(
+                            &staker_id,
+                            frame_system::Pallet::<T>::block_number(),
+                            amount_withdrawn,
+                        );
 
                         // User is fully unbonded, so we emit an event
                         Pallet::<T>::deposit_event(Event::<T>::UnstakingClaimed {
@@ -464,6 +506,20 @@ pub mod pallet {
     #[pallet::getter(fn last_processed_user_nonce)]
     pub(super) type LastProcessedUserNonce<T: Config> =
         StorageMap<_, Blake2_128Concat, T::AccountId, U256>;
+
+    /// Unstakes that have been claimed through an `UNSTAKECLAIMED` insert.
+    ///
+    /// Pruned after processing via an `UNSTAKED` insert.
+    #[pallet::storage]
+    #[pallet::getter(fn claimed_unstake)]
+    pub(super) type ClaimedUnstakes<T: Config> = StorageDoubleMap<
+        _,
+        Blake2_128Concat,
+        T::AccountId,
+        Blake2_128Concat,
+        BlockNumberFor<T>,
+        T::CurrencyBalance,
+    >;
 
     fn consume_nonce<T: Config>(nonce: U256, eth_sender: &T::AccountId) -> DispatchResult {
         let expected =

--- a/pallets/system_tables/src/lib.rs
+++ b/pallets/system_tables/src/lib.rs
@@ -222,7 +222,7 @@ pub mod pallet {
                         )?;
 
                         // If the user already had a bonded amount use bond_extra
-                        if balance > 0 {
+                        if pallet_staking::Pallet::<T>::bonded(&staker_id).is_some() {
                             pallet_staking::Pallet::<T>::bond_extra(
                                 staker_signer.clone().into(),
                                 stake_amount,

--- a/pallets/system_tables/src/lib.rs
+++ b/pallets/system_tables/src/lib.rs
@@ -307,17 +307,8 @@ pub mod pallet {
                         let staker = hex::encode(staker);
                         let staker_id =
                             sxt_core::utils::eth_address_to_substrate_account_id::<T>(&staker)?;
-                        let staker_signer: OriginFor<T> =
-                            RawOrigin::Signed(staker_id.clone()).into();
 
                         let stake_amount = amount.min(&U256::from(u128::MAX)).low_u128();
-
-                        // Burn the unbonded amount from the account
-                        pallet_balances::Pallet::<T>::burn(
-                            staker_signer,
-                            stake_amount.saturated_into(),
-                            false,
-                        )?;
 
                         Ok(())
                     }
@@ -358,7 +349,7 @@ pub mod pallet {
                         // has all fields private to the staking crate. For now the
                         // best we can do is to call the withdraw function and see if there are any
                         // balance changes.
-                        pallet_staking::Pallet::<T>::withdraw_unbonded(staker_signer, 0u32)
+                        pallet_staking::Pallet::<T>::withdraw_unbonded(staker_signer.clone(), 0u32)
                             .map_err(|e| e.error)?;
 
                         // Check if the user still has entries in the staking ledger
@@ -376,6 +367,13 @@ pub mod pallet {
                         Pallet::<T>::deposit_event(Event::<T>::UnstakingClaimed {
                             claimer: staker_id.clone(),
                         });
+
+                        // Burn the unbonded amount from the account
+                        pallet_balances::Pallet::<T>::burn(
+                            staker_signer,
+                            amount_withdrawn.saturated_into(),
+                            false,
+                        )?;
 
                         Ok(())
                     }

--- a/pallets/system_tables/src/runtime_api.rs
+++ b/pallets/system_tables/src/runtime_api.rs
@@ -1,0 +1,14 @@
+//! Runtime APIs for reading from pallet-system-tables.
+
+use alloc::vec::Vec;
+
+use codec::FullCodec;
+use sxt_core::system_tables::ClaimedUnstake;
+
+sp_api::decl_runtime_apis! {
+    /// Runtime APIs for reading from pallet-system-tables.
+    pub trait SystemTablesApi<AccountId, BlockNumber, CurrencyBalance> where AccountId: FullCodec, BlockNumber: FullCodec, CurrencyBalance: FullCodec {
+        /// Returns a list of all currently-processing claimed unstakes.
+        fn claimed_unstakes() -> Vec<ClaimedUnstake<AccountId, BlockNumber, CurrencyBalance>>;
+    }
+}

--- a/pallets/system_tables/src/tests.rs
+++ b/pallets/system_tables/src/tests.rs
@@ -4,7 +4,7 @@ use on_chain_table::OnChainTable;
 use sp_core::crypto::AccountId32;
 use sp_core::U256;
 use sp_runtime::traits::StaticLookup;
-use sp_runtime::{DispatchError, Perbill, TokenError};
+use sp_runtime::{DispatchError, Perbill};
 use sp_staking::StakingInterface;
 use sxt_core::parse::{
     MessageSystemRequest,
@@ -14,6 +14,7 @@ use sxt_core::parse::{
     SystemRequestType,
     SystemTableField,
 };
+use sxt_core::system_tables::ClaimedUnstake;
 use sxt_core::tables::TableIdentifier;
 use sxt_core::utils::{
     account_id_from_str,
@@ -439,6 +440,8 @@ fn unstaking_works_end_to_end_and_reduces_balance_when_claimed() {
         assert!(current_era() > duration_in_eras);
         System::reset_events();
 
+        assert!(Pallet::<Test>::claimed_unstakes().is_empty());
+
         let claim_unstake = get_claim_unstake_message(ETH_TEST_WALLET);
         assert_ok!(crate::process_unstake_claimed::<Test>(claim_unstake));
 
@@ -448,6 +451,18 @@ fn unstaking_works_end_to_end_and_reduces_balance_when_claimed() {
             amount: test_amount,
         }));
 
+        let current_block_number = frame_system::Pallet::<Test>::block_number();
+
+        // Ensure the claimed unstake state has been populated
+        assert_eq!(
+            Pallet::<Test>::claimed_unstakes(),
+            vec![ClaimedUnstake {
+                staker: transformed_eth_wallet.clone(),
+                claim_block_number: current_block_number,
+                claimed_amount: test_amount
+            }]
+        );
+
         // Ensure the claim event has been emitted
         System::assert_has_event(RuntimeEvent::SystemTables(crate::Event::UnstakingClaimed {
             claimer: transformed_eth_wallet.clone(),
@@ -456,6 +471,247 @@ fn unstaking_works_end_to_end_and_reduces_balance_when_claimed() {
         // Confirm the unstake as if the contract did
         let unstaked = get_unstaked_message(ETH_TEST_WALLET, test_amount.into());
         assert_ok!(crate::process_unstaked::<Test>(unstaked));
+
+        // Ensure the claimed unstake state has been pruned
+        assert!(Pallet::<Test>::claimed_unstakes().is_empty());
+    });
+}
+
+#[test]
+fn partial_unstaking_works_end_to_end_and_reduces_balance_when_claimed() {
+    new_test_ext().execute_with(|| {
+        // Start at era 1
+        crate::mock::start_active_era(1);
+        System::reset_events();
+
+        // Create a message to stake 100 using the ethereum address
+        let bonding = get_staked_message(ETH_TEST_WALLET, 100.into());
+
+        // Now we do lookups based on the converted address to assure that state is set correctly
+        let transformed_eth_wallet =
+            eth_address_to_substrate_account_id::<Test>(ETH_TEST_WALLET).unwrap();
+
+        // complicate the situation by adding some unlocked funds to the account too
+        pallet_balances::Pallet::<Test>::force_set_balance(
+            RawOrigin::Root.into(),
+            transformed_eth_wallet.clone(),
+            200,
+        )
+        .unwrap();
+
+        // Make sure the staking suceeded and events were emitted as expected
+        assert_eq!(
+            pallet_staking::Pallet::<Test>::bonded(&transformed_eth_wallet),
+            None
+        );
+
+        // Process the staking request
+        assert_ok!(crate::process_staking::<Test>(bonding));
+
+        // Make sure the staking suceeded and events were emitted as expected
+        assert_eq!(
+            pallet_staking::Pallet::<Test>::bonded(&transformed_eth_wallet),
+            Some(transformed_eth_wallet.clone())
+        );
+
+        // check that usable balance hasn't changed
+        assert_eq!(
+            pallet_balances::Pallet::<Test>::free_balance(&transformed_eth_wallet),
+            300
+        );
+        assert_eq!(
+            pallet_balances::Pallet::<Test>::usable_balance(&transformed_eth_wallet),
+            200
+        );
+        assert_eq!(
+            pallet_staking::Pallet::<Test>::ledger(transformed_eth_wallet.clone().into())
+                .unwrap()
+                .total,
+            100
+        );
+        System::assert_has_event(RuntimeEvent::Staking(pallet_staking::Event::Bonded {
+            stash: transformed_eth_wallet.clone(),
+            amount: 100,
+        }));
+
+        // Now go to one era in the future
+        crate::mock::start_active_era(2);
+        System::reset_events();
+
+        let initiate_unstake = get_initiate_unstake_message(ETH_TEST_WALLET, 60.into());
+
+        // Call Unstake for only 60 tokens
+        assert_ok!(crate::process_unstake_initiated::<Test>(initiate_unstake));
+
+        // check that balance hasn't changed
+        assert_eq!(
+            pallet_balances::Pallet::<Test>::free_balance(&transformed_eth_wallet),
+            300
+        );
+        assert_eq!(
+            pallet_balances::Pallet::<Test>::usable_balance(&transformed_eth_wallet),
+            200
+        );
+
+        // Assert than an unbonded event has occurred for the user in the staking pallet
+        System::assert_has_event(RuntimeEvent::Staking(pallet_staking::Event::Unbonded {
+            stash: transformed_eth_wallet.clone(),
+            amount: 60,
+        }));
+
+        // Jump forward by one whole bonding duration + 1 era
+        let duration_in_eras = <Test as pallet_staking::Config>::BondingDuration::get() + 7;
+        crate::mock::start_active_era(current_era() + duration_in_eras + 1);
+
+        assert!(current_era() > duration_in_eras);
+        System::reset_events();
+
+        assert!(Pallet::<Test>::claimed_unstakes().is_empty());
+
+        let claim_unstake = get_claim_unstake_message(ETH_TEST_WALLET);
+        assert_ok!(crate::process_unstake_claimed::<Test>(claim_unstake));
+
+        // check that free balance has been reduced and usable balance hasn't changed
+        assert_eq!(
+            pallet_balances::Pallet::<Test>::free_balance(&transformed_eth_wallet),
+            240
+        );
+        assert_eq!(
+            pallet_balances::Pallet::<Test>::usable_balance(&transformed_eth_wallet),
+            200
+        );
+
+        let current_block_number = frame_system::Pallet::<Test>::block_number();
+
+        // Ensure the claimed unstake state has been populated
+        assert_eq!(
+            Pallet::<Test>::claimed_unstakes(),
+            vec![ClaimedUnstake {
+                staker: transformed_eth_wallet.clone(),
+                claim_block_number: current_block_number,
+                claimed_amount: 60
+            }]
+        );
+
+        //Ensure we can see the token burn
+        System::assert_has_event(RuntimeEvent::Balances(pallet_balances::Event::Burned {
+            who: transformed_eth_wallet.clone(),
+            amount: 60,
+        }));
+
+        // Ensure the claim event has been emitted
+        System::assert_has_event(RuntimeEvent::SystemTables(crate::Event::UnstakingClaimed {
+            claimer: transformed_eth_wallet.clone(),
+        }));
+
+        // Confirm the unstake as if the contract did
+        let unstaked = get_unstaked_message(ETH_TEST_WALLET, 60.into());
+        assert_ok!(crate::process_unstaked::<Test>(unstaked));
+
+        // check that balance hasn't changed
+        assert_eq!(
+            pallet_balances::Pallet::<Test>::free_balance(&transformed_eth_wallet),
+            240
+        );
+        assert_eq!(
+            pallet_balances::Pallet::<Test>::usable_balance(&transformed_eth_wallet),
+            200
+        );
+
+        // Ensure the total is 40 (not 0)
+        assert_eq!(
+            pallet_staking::Pallet::<Test>::ledger(transformed_eth_wallet.clone().into())
+                .unwrap()
+                .total,
+            40
+        );
+
+        // Ensure the claimed unstake state has been pruned
+        assert!(Pallet::<Test>::claimed_unstakes().is_empty());
+
+        // unstake the rest
+        let initiate_unstake = get_initiate_unstake_message(ETH_TEST_WALLET, 40.into());
+
+        // Call Unstake
+        assert_ok!(crate::process_unstake_initiated::<Test>(initiate_unstake));
+
+        // check that balances haven't changed
+        assert_eq!(
+            pallet_balances::Pallet::<Test>::free_balance(&transformed_eth_wallet),
+            240
+        );
+        assert_eq!(
+            pallet_balances::Pallet::<Test>::usable_balance(&transformed_eth_wallet),
+            200
+        );
+
+        // Assert than an unbonded event has occurred for the user in the staking pallet
+        System::assert_has_event(RuntimeEvent::Staking(pallet_staking::Event::Unbonded {
+            stash: transformed_eth_wallet.clone(),
+            amount: 40,
+        }));
+
+        // Jump forward by one whole bonding duration + 1 era
+        let duration_in_eras = <Test as pallet_staking::Config>::BondingDuration::get() + 7;
+        crate::mock::start_active_era(current_era() + duration_in_eras + 1);
+
+        assert!(current_era() > duration_in_eras);
+        System::reset_events();
+
+        assert!(Pallet::<Test>::claimed_unstakes().is_empty());
+
+        let claim_unstake = get_claim_unstake_message(ETH_TEST_WALLET);
+        assert_ok!(crate::process_unstake_claimed::<Test>(claim_unstake));
+
+        // check that free balance has reduced but usable hasn't changed
+        assert_eq!(
+            pallet_balances::Pallet::<Test>::free_balance(&transformed_eth_wallet),
+            200
+        );
+        assert_eq!(
+            pallet_balances::Pallet::<Test>::usable_balance(&transformed_eth_wallet),
+            200
+        );
+
+        let current_block_number = frame_system::Pallet::<Test>::block_number();
+
+        // Ensure the claimed unstake state has been populated
+        assert_eq!(
+            Pallet::<Test>::claimed_unstakes(),
+            vec![ClaimedUnstake {
+                staker: transformed_eth_wallet.clone(),
+                claim_block_number: current_block_number,
+                claimed_amount: 40
+            }]
+        );
+
+        //Ensure we can see the token burn
+        System::assert_has_event(RuntimeEvent::Balances(pallet_balances::Event::Burned {
+            who: transformed_eth_wallet.clone(),
+            amount: 40,
+        }));
+
+        // Ensure the claim event has been emitted
+        System::assert_has_event(RuntimeEvent::SystemTables(crate::Event::UnstakingClaimed {
+            claimer: transformed_eth_wallet.clone(),
+        }));
+
+        // Confirm the unstake as if the contract did
+        let unstaked = get_unstaked_message(ETH_TEST_WALLET, 40.into());
+        assert_ok!(crate::process_unstaked::<Test>(unstaked));
+
+        // check that balances haven't changed
+        assert_eq!(
+            pallet_balances::Pallet::<Test>::free_balance(&transformed_eth_wallet),
+            200
+        );
+        assert_eq!(
+            pallet_balances::Pallet::<Test>::usable_balance(&transformed_eth_wallet),
+            200
+        );
+
+        // Ensure the claimed unstake state has been pruned
+        assert!(Pallet::<Test>::claimed_unstakes().is_empty());
     });
 }
 
@@ -501,9 +757,13 @@ fn attempting_to_claim_before_unbonding_period_produces_error() {
         crate::mock::start_active_era(3);
         System::reset_events();
 
+        assert!(Pallet::<Test>::claimed_unstakes().is_empty());
+
         let claim_unstake = get_claim_unstake_message(ETH_TEST_WALLET);
 
         assert_ok!(crate::process_unstake_claimed::<Test>(claim_unstake));
+
+        assert!(Pallet::<Test>::claimed_unstakes().is_empty());
 
         // Ensure there was an error emitted
         System::assert_has_event(RuntimeEvent::SystemTables(
@@ -517,6 +777,7 @@ fn attempting_to_claim_before_unbonding_period_produces_error() {
         // Make sure that even if we call unstake, we don't get the balance back
         let unstaked = get_unstaked_message(ETH_TEST_WALLET, test_amount.into());
         assert_ok!(crate::process_unstaked::<Test>(unstaked));
+        assert!(Pallet::<Test>::claimed_unstakes().is_empty());
     });
 }
 

--- a/pallets/system_tables/src/tests.rs
+++ b/pallets/system_tables/src/tests.rs
@@ -442,6 +442,12 @@ fn unstaking_works_end_to_end_and_reduces_balance_when_claimed() {
         let claim_unstake = get_claim_unstake_message(ETH_TEST_WALLET);
         assert_ok!(crate::process_unstake_claimed::<Test>(claim_unstake));
 
+        //Ensure we can see the token burn
+        System::assert_has_event(RuntimeEvent::Balances(pallet_balances::Event::Burned {
+            who: transformed_eth_wallet.clone(),
+            amount: test_amount,
+        }));
+
         // Ensure the claim event has been emitted
         System::assert_has_event(RuntimeEvent::SystemTables(crate::Event::UnstakingClaimed {
             claimer: transformed_eth_wallet.clone(),
@@ -450,12 +456,6 @@ fn unstaking_works_end_to_end_and_reduces_balance_when_claimed() {
         // Confirm the unstake as if the contract did
         let unstaked = get_unstaked_message(ETH_TEST_WALLET, test_amount.into());
         assert_ok!(crate::process_unstaked::<Test>(unstaked));
-
-        //Ensure we can see the token burn
-        System::assert_has_event(RuntimeEvent::Balances(pallet_balances::Event::Burned {
-            who: transformed_eth_wallet,
-            amount: test_amount,
-        }));
     });
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -166,7 +166,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 234,
+    spec_version: 235,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -86,6 +86,7 @@ use sp_staking::SessionIndex;
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
+use sxt_core::system_tables::ClaimedUnstake;
 pub use {
     pallet_attestation,
     pallet_authority_discovery,
@@ -1331,6 +1332,12 @@ impl_runtime_apis! {
     impl pallet_tables::runtime_api::TablesApi<Block> for Runtime {
         fn table_schema(table_identifier: sxt_core::tables::TableIdentifier) -> Result<sxt_core::tables::TableSchema, sxt_core::tables::GetTableSchemaError> {
             Tables::table_schema(table_identifier)
+        }
+    }
+
+    impl pallet_system_tables::runtime_api::SystemTablesApi<Block, AccountId, BlockNumber, Balance> for Runtime {
+        fn claimed_unstakes() -> Vec<ClaimedUnstake<AccountId, BlockNumber, Balance>> {
+            SystemTables::claimed_unstakes()
         }
     }
 }

--- a/sxt-core/src/lib.rs
+++ b/sxt-core/src/lib.rs
@@ -46,6 +46,9 @@ pub mod smartcontracts;
 /// Types related to the system contracts pallet;
 pub mod system_contracts;
 
+/// Types related to the system tables pallet
+pub mod system_tables;
+
 /// Utility functions for handling Runtime types
 pub mod utils;
 

--- a/sxt-core/src/sxt_chain_runtime.rs
+++ b/sxt-core/src/sxt_chain_runtime.rs
@@ -39,7 +39,7 @@ pub mod api {
         "Rewards",
         "ZkPay",
     ];
-    pub static RUNTIME_APIS: [&str; 17usize] = [
+    pub static RUNTIME_APIS: [&str; 18usize] = [
         "Core",
         "Metadata",
         "BlockBuilder",
@@ -57,6 +57,7 @@ pub mod api {
         "AuthorityDiscoveryApi",
         "CommitmentsApi",
         "TablesApi",
+        "SystemTablesApi",
     ];
     #[doc = r" The error type that is returned when there is a runtime issue."]
     pub type DispatchError = runtime_types::sp_runtime::DispatchError;
@@ -142,6 +143,9 @@ pub mod api {
             }
             pub fn tables_api(&self) -> tables_api::TablesApi {
                 tables_api::TablesApi
+            }
+            pub fn system_tables_api(&self) -> system_tables_api::SystemTablesApi {
+                system_tables_api::SystemTablesApi
             }
         }
         pub mod core {
@@ -2446,9 +2450,64 @@ pub mod api {
                 }
             }
         }
-    }
-    pub fn view_functions() -> ViewFunctionsApi {
-        ViewFunctionsApi
+        pub mod system_tables_api {
+            use super::{root_mod, runtime_types};
+            #[doc = " Runtime APIs for reading from pallet-system-tables."]
+            pub struct SystemTablesApi;
+            impl SystemTablesApi {
+                #[doc = " Returns a list of all currently-processing claimed unstakes."]
+                pub fn claimed_unstakes(
+                    &self,
+                ) -> ::subxt::ext::subxt_core::runtime_api::payload::StaticPayload<
+                    types::ClaimedUnstakes,
+                    types::claimed_unstakes::output::Output,
+                > {
+                    ::subxt::ext::subxt_core::runtime_api::payload::StaticPayload::new_static(
+                        "SystemTablesApi",
+                        "claimed_unstakes",
+                        types::ClaimedUnstakes {},
+                        [
+                            120u8, 130u8, 108u8, 246u8, 246u8, 206u8, 131u8, 214u8, 46u8, 202u8,
+                            4u8, 234u8, 71u8, 118u8, 245u8, 5u8, 176u8, 251u8, 51u8, 84u8, 74u8,
+                            174u8, 140u8, 213u8, 184u8, 49u8, 32u8, 144u8, 89u8, 140u8, 25u8,
+                            210u8,
+                        ],
+                    )
+                }
+            }
+            pub mod types {
+                use super::runtime_types;
+                pub mod claimed_unstakes {
+                    use super::runtime_types;
+                    pub mod output {
+                        use super::runtime_types;
+                        pub type Output = ::subxt::ext::subxt_core::alloc::vec::Vec<
+                            runtime_types::sxt_core::system_tables::ClaimedUnstake<
+                                ::subxt::ext::subxt_core::utils::AccountId32,
+                                ::core::primitive::u32,
+                                ::core::primitive::u128,
+                            >,
+                        >;
+                    }
+                }
+                #[derive(
+                    :: subxt :: ext :: subxt_core :: ext :: codec :: Decode,
+                    :: subxt :: ext :: subxt_core :: ext :: codec :: Encode,
+                    :: subxt :: ext :: subxt_core :: ext :: scale_decode :: DecodeAsType,
+                    :: subxt :: ext :: subxt_core :: ext :: scale_encode :: EncodeAsType,
+                    Debug,
+                )]
+                # [codec (crate = :: subxt :: ext :: subxt_core :: ext :: codec)]
+                #[codec(dumb_trait_bound)]
+                #[decode_as_type(
+                    crate_path = ":: subxt :: ext :: subxt_core :: ext :: scale_decode"
+                )]
+                #[encode_as_type(
+                    crate_path = ":: subxt :: ext :: subxt_core :: ext :: scale_encode"
+                )]
+                pub struct ClaimedUnstakes {}
+            }
+        }
     }
     pub fn custom() -> CustomValuesApi {
         CustomValuesApi
@@ -2671,8 +2730,6 @@ pub mod api {
             zk_pay::calls::TransactionApi
         }
     }
-    pub struct ViewFunctionsApi;
-    impl ViewFunctionsApi {}
     #[doc = r" check whether the metadata provided is aligned with this statically generated code."]
     pub fn is_codegen_valid_for(metadata: &::subxt::ext::subxt_core::Metadata) -> bool {
         let runtime_metadata_hash = metadata
@@ -2682,9 +2739,9 @@ pub mod api {
             .hash();
         runtime_metadata_hash
             == [
-                109u8, 55u8, 14u8, 117u8, 22u8, 122u8, 42u8, 211u8, 48u8, 231u8, 59u8, 175u8,
-                214u8, 202u8, 51u8, 50u8, 217u8, 46u8, 24u8, 79u8, 105u8, 47u8, 116u8, 229u8, 27u8,
-                54u8, 138u8, 8u8, 252u8, 239u8, 171u8, 142u8,
+                154u8, 0u8, 117u8, 164u8, 118u8, 85u8, 231u8, 255u8, 7u8, 230u8, 172u8, 116u8,
+                245u8, 23u8, 228u8, 101u8, 56u8, 83u8, 225u8, 141u8, 55u8, 211u8, 199u8, 65u8,
+                114u8, 251u8, 14u8, 22u8, 103u8, 112u8, 32u8, 71u8,
             ]
     }
     pub mod system {
@@ -21333,6 +21390,12 @@ pub mod api {
                     pub type LastProcessedUserNonce = runtime_types::primitive_types::U256;
                     pub type Param0 = ::subxt::ext::subxt_core::utils::AccountId32;
                 }
+                pub mod claimed_unstakes {
+                    use super::runtime_types;
+                    pub type ClaimedUnstakes = ::core::primitive::u128;
+                    pub type Param0 = ::subxt::ext::subxt_core::utils::AccountId32;
+                    pub type Param1 = ::core::primitive::u32;
+                }
             }
             pub struct StorageApi;
             impl StorageApi {
@@ -21399,6 +21462,96 @@ pub mod api {
                             17u8, 76u8, 178u8, 95u8, 186u8, 30u8, 65u8, 26u8, 105u8, 206u8, 182u8,
                             235u8, 200u8, 79u8, 2u8, 163u8, 81u8, 239u8, 53u8, 7u8, 226u8, 104u8,
                             98u8, 14u8, 169u8, 228u8, 160u8, 50u8, 73u8, 95u8, 190u8, 251u8,
+                        ],
+                    )
+                }
+                #[doc = " Unstakes that have been claimed through an `UNSTAKECLAIMED` insert."]
+                #[doc = ""]
+                #[doc = " Pruned after processing via an `UNSTAKED` insert."]
+                pub fn claimed_unstakes_iter(
+                    &self,
+                ) -> ::subxt::ext::subxt_core::storage::address::StaticAddress<
+                    (),
+                    types::claimed_unstakes::ClaimedUnstakes,
+                    (),
+                    (),
+                    ::subxt::ext::subxt_core::utils::Yes,
+                > {
+                    ::subxt::ext::subxt_core::storage::address::StaticAddress::new_static(
+                        "SystemTables",
+                        "ClaimedUnstakes",
+                        (),
+                        [
+                            133u8, 106u8, 51u8, 139u8, 76u8, 20u8, 63u8, 28u8, 181u8, 8u8, 90u8,
+                            224u8, 127u8, 254u8, 187u8, 35u8, 162u8, 209u8, 206u8, 212u8, 91u8,
+                            215u8, 26u8, 234u8, 0u8, 41u8, 66u8, 211u8, 72u8, 224u8, 115u8, 87u8,
+                        ],
+                    )
+                }
+                #[doc = " Unstakes that have been claimed through an `UNSTAKECLAIMED` insert."]
+                #[doc = ""]
+                #[doc = " Pruned after processing via an `UNSTAKED` insert."]
+                pub fn claimed_unstakes_iter1(
+                    &self,
+                    _0: impl ::core::borrow::Borrow<types::claimed_unstakes::Param0>,
+                ) -> ::subxt::ext::subxt_core::storage::address::StaticAddress<
+                    ::subxt::ext::subxt_core::storage::address::StaticStorageKey<
+                        types::claimed_unstakes::Param0,
+                    >,
+                    types::claimed_unstakes::ClaimedUnstakes,
+                    (),
+                    (),
+                    ::subxt::ext::subxt_core::utils::Yes,
+                > {
+                    ::subxt::ext::subxt_core::storage::address::StaticAddress::new_static(
+                        "SystemTables",
+                        "ClaimedUnstakes",
+                        ::subxt::ext::subxt_core::storage::address::StaticStorageKey::new(
+                            _0.borrow(),
+                        ),
+                        [
+                            133u8, 106u8, 51u8, 139u8, 76u8, 20u8, 63u8, 28u8, 181u8, 8u8, 90u8,
+                            224u8, 127u8, 254u8, 187u8, 35u8, 162u8, 209u8, 206u8, 212u8, 91u8,
+                            215u8, 26u8, 234u8, 0u8, 41u8, 66u8, 211u8, 72u8, 224u8, 115u8, 87u8,
+                        ],
+                    )
+                }
+                #[doc = " Unstakes that have been claimed through an `UNSTAKECLAIMED` insert."]
+                #[doc = ""]
+                #[doc = " Pruned after processing via an `UNSTAKED` insert."]
+                pub fn claimed_unstakes(
+                    &self,
+                    _0: impl ::core::borrow::Borrow<types::claimed_unstakes::Param0>,
+                    _1: impl ::core::borrow::Borrow<types::claimed_unstakes::Param1>,
+                ) -> ::subxt::ext::subxt_core::storage::address::StaticAddress<
+                    (
+                        ::subxt::ext::subxt_core::storage::address::StaticStorageKey<
+                            types::claimed_unstakes::Param0,
+                        >,
+                        ::subxt::ext::subxt_core::storage::address::StaticStorageKey<
+                            types::claimed_unstakes::Param1,
+                        >,
+                    ),
+                    types::claimed_unstakes::ClaimedUnstakes,
+                    ::subxt::ext::subxt_core::utils::Yes,
+                    (),
+                    (),
+                > {
+                    ::subxt::ext::subxt_core::storage::address::StaticAddress::new_static(
+                        "SystemTables",
+                        "ClaimedUnstakes",
+                        (
+                            ::subxt::ext::subxt_core::storage::address::StaticStorageKey::new(
+                                _0.borrow(),
+                            ),
+                            ::subxt::ext::subxt_core::storage::address::StaticStorageKey::new(
+                                _1.borrow(),
+                            ),
+                        ),
+                        [
+                            133u8, 106u8, 51u8, 139u8, 76u8, 20u8, 63u8, 28u8, 181u8, 8u8, 90u8,
+                            224u8, 127u8, 254u8, 187u8, 35u8, 162u8, 209u8, 206u8, 212u8, 91u8,
+                            215u8, 26u8, 234u8, 0u8, 41u8, 66u8, 211u8, 72u8, 224u8, 115u8, 87u8,
                         ],
                     )
                 }
@@ -27417,6 +27570,9 @@ pub mod api {
                     #[codec(index = 14)]
                     #[doc = "Occurs when attempting to claim locked funds"]
                     FundsLocked,
+                    #[codec(index = 15)]
+                    #[doc = "Account was not claiming unstake."]
+                    NoSuchClaimedUnstake,
                 }
                 #[derive(
                     :: subxt :: ext :: subxt_core :: ext :: codec :: Decode,
@@ -30872,6 +31028,29 @@ pub mod api {
                 pub struct ContractInfo {
                     pub chain_id: runtime_types::primitive_types::U256,
                     pub address: ::subxt::ext::subxt_core::utils::H160,
+                }
+            }
+            pub mod system_tables {
+                use super::runtime_types;
+                #[derive(
+                    :: subxt :: ext :: subxt_core :: ext :: codec :: Decode,
+                    :: subxt :: ext :: subxt_core :: ext :: codec :: Encode,
+                    :: subxt :: ext :: subxt_core :: ext :: scale_decode :: DecodeAsType,
+                    :: subxt :: ext :: subxt_core :: ext :: scale_encode :: EncodeAsType,
+                    Debug,
+                )]
+                # [codec (crate = :: subxt :: ext :: subxt_core :: ext :: codec)]
+                #[codec(dumb_trait_bound)]
+                #[decode_as_type(
+                    crate_path = ":: subxt :: ext :: subxt_core :: ext :: scale_decode"
+                )]
+                #[encode_as_type(
+                    crate_path = ":: subxt :: ext :: subxt_core :: ext :: scale_encode"
+                )]
+                pub struct ClaimedUnstake<_0, _1, _2> {
+                    pub staker: _0,
+                    pub claim_block_number: _1,
+                    pub claimed_amount: _2,
                 }
             }
             pub mod tables {

--- a/sxt-core/src/system_tables.rs
+++ b/sxt-core/src/system_tables.rs
@@ -1,0 +1,18 @@
+use codec::{Decode, Encode, FullCodec};
+use scale_info::TypeInfo;
+
+/// Unstakes that have been claimed through the system-tables pallet.
+#[derive(Clone, Debug, Encode, Decode, Eq, PartialEq, Default, TypeInfo)]
+pub struct ClaimedUnstake<AccountId, BlockNumber, CurrencyBalance>
+where
+    AccountId: FullCodec,
+    BlockNumber: FullCodec,
+    CurrencyBalance: FullCodec,
+{
+    /// The staker that is claiming their unstake amount.
+    pub staker: AccountId,
+    /// The block that the claim occurred in.
+    pub claim_block_number: BlockNumber,
+    /// The unstake amount that was claimed.
+    pub claimed_amount: CurrencyBalance,
+}


### PR DESCRIPTION
# Rationale for this change
The system tables unstaking flow depends on attestors attesting to uniquely identifiable unstake amounts once they have been claimed. Currently there's not a great storage item for them to read that satisfies these requirements. This adds such a storage item, which is managed for unstaking done through system tables. It also adds a runtime API for accessing the entire collection, which attestors will use soon. 
Some other staking fixes that were revealed by these changes have also been included.

# What changes are included in this PR?
- checks for bonded accounts instead of those with nonzero balance when choosing to `bond_extra`
- burns withrdrawn amounts immediately
- adds storage item `ClaimedUnstakes`
- adds `claimed_unstakes` runtime api getting the entire collection
- manages `ClaimedUnstakes` storage when in the `unstake_claimed` and `unstaked` process functions
- increments runtime spec version
- regenerates sxt_chain_runtime.rs

# Are these changes tested?
Yes.
