### PR TITLE
ci: add hash of runtime to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,14 +112,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - uses: ./.github/actions/free-disk-space
       - uses: ./.github/actions/ubuntu-dependencies
 
-      - name: Build the Dockerfile
+      - name: Build
         run: |-
           cargo build --locked --release
+        timeout-minutes: 90
+
+      - name: Compute / Print hashes
+        run: |
+          echo "Recent Git Commits:"
+          git log --pretty=format:"%H %d %s" $(git describe --tags --abbrev=0)^..HEAD
+          echo "Runtime Code Hash:"
+          b2sum -l 256 target/release/wbuild/sxt-runtime/sxt_runtime.compact.compressed.wasm
+          echo "Sudo Call Data:"
+          cat <(echo -n "0x16000009") <(b2sum -l 256 target/release/wbuild/sxt-runtime/sxt_runtime.compact.compressed.wasm)
+          echo "Call Hash:"
+          cat <(echo -n "16000009") <(b2sum -l 256 target/release/wbuild/sxt-runtime/sxt_runtime.compact.compressed.wasm) | xxd -r -p | b2sum -l 256
+
+      - name: Build the Dockerfile
+        run: |-
           docker buildx version
           docker buildx ls
           docker buildx build -f ./sxtnode.Dockerfile . -t sxt-node
-        timeout-minutes: 90

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,8 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           ref: ${{ github.head_ref }}
+          fetch-depth: 0
+          fetch-tags: true
       - uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_URL: https://${{ secrets.REGISTRY_URL }}
@@ -87,9 +89,23 @@ jobs:
         run: |-
           set -eux
           cargo build --locked --release
+          b2sum -l 256 target/release/wbuild/sxt-runtime/sxt_runtime.compact.compressed.wasm
           jf rt u --flat target/release/sxt-node sxtnode-generic-local/sxt-node/$VERSION/;
           jf rt u --flat target/release/wbuild/sxt-runtime/sxt_runtime.compact.compressed.wasm sxtnode-generic-local/sxt-node/$VERSION/;
         timeout-minutes: 90
+      
+      - name: Compute / Print hashes
+        if: ${{ !contains(matrix.os, 'macos') }}
+        run: |
+          echo "Recent Git Commits:"
+          git log --pretty=format:"%H %d %s" $(git describe --tags --abbrev=0)^..HEAD
+          echo "Runtime Code Hash:"
+          b2sum -l 256 target/release/wbuild/sxt-runtime/sxt_runtime.compact.compressed.wasm
+          echo "Sudo Call Data:"
+          cat <(echo -n "0x16000009") <(b2sum -l 256 target/release/wbuild/sxt-runtime/sxt_runtime.compact.compressed.wasm)
+          echo "Call Hash:"
+          cat <(echo -n "16000009") <(b2sum -l 256 target/release/wbuild/sxt-runtime/sxt_runtime.compact.compressed.wasm) | xxd -r -p | b2sum -l 256
+
       - uses: actions/upload-artifact@v4
         with:
           name: artifact_sxtnode


### PR DESCRIPTION
# Rationale for this change

It is tedious to audit a runtime upgrade.

# Changes

The CI now prints the following in one spot:
* Recent Git Commits (from most recent tag to HEAD)
* Runtime Code Hash
* Sudo Call Data
* Call Hash
