### PR TITLE
fix: correct block number usage in claimed unstake attestations

### DIFF
--- a/pallets/attestation/src/benchmarking.rs
+++ b/pallets/attestation/src/benchmarking.rs
@@ -130,7 +130,7 @@ mod benchmarks {
         #[extrinsic_call]
         attest_block(
             RawOrigin::Signed(caller.clone()),
-            block_number,
+            Some(block_number),
             attestation.clone(),
         );
 

--- a/pallets/attestation/src/lib.rs
+++ b/pallets/attestation/src/lib.rs
@@ -28,6 +28,7 @@ pub use weights::*;
 pub mod pallet {
     use frame_support::dispatch::DispatchResult;
     use frame_support::pallet_prelude::{OptionQuery, *};
+    use frame_support::sp_runtime::traits::UniqueSaturatedInto;
     use frame_support::Blake2_128Concat;
     use frame_system::pallet_prelude::*;
     use sxt_core::attestation::{create_attestation_message, Attestation, AttestationKey};
@@ -137,7 +138,7 @@ pub mod pallet {
         /// Submit a block attestation.
         ///
         /// # Arguments
-        /// * `block_number` - The block being attested.
+        /// * `block_number` - The block being attested. If not provided, uses the current block.
         /// * `attestation` - The attestation details.
         ///
         /// # Emits
@@ -147,26 +148,27 @@ pub mod pallet {
         /// * [`Error::CannotAttestFutureBlock`]
         /// * [`Error::CannotAttestCurrentBlock`]
         /// * [`Error::MaxAttestationsForBlockError`]
-        /// * [`Error::AttestationAlreadyRecordedError`]
         #[pallet::call_index(0)]
         #[pallet::weight(<T as Config>::WeightInfo::attest_block())]
         pub fn attest_block(
             origin: OriginFor<T>,
-            block_number: BlockNumber,
+            block_number: Option<BlockNumber>,
             attestation: Attestation<T::Hash>,
         ) -> DispatchResult {
             let who = ensure_signed(origin.clone())?;
 
-            let current_block = frame_system::Pallet::<T>::block_number();
+            let current_block = frame_system::Pallet::<T>::block_number().unique_saturated_into();
 
-            ensure!(
-                current_block > block_number.into(),
-                Error::<T>::CannotAttestFutureBlock
-            );
-            ensure!(
-                current_block != block_number.into(),
-                Error::<T>::CannotAttestCurrentBlock
-            );
+            if let Some(block_number) = block_number {
+                ensure!(
+                    current_block > block_number,
+                    Error::<T>::CannotAttestFutureBlock
+                );
+                ensure!(
+                    current_block != block_number,
+                    Error::<T>::CannotAttestCurrentBlock
+                );
+            }
 
             pallet_permissions::Pallet::<T>::ensure_root_or_permissioned(
                 origin,
@@ -179,7 +181,7 @@ pub mod pallet {
                     proposed_pub_key: attestor_pub_key,
                     ref address20,
                     ref state_root,
-                    block_number,
+                    block_number: attested_block_number,
                     ..
                 } => {
                     let proposed_key = EthereumKey {
@@ -188,7 +190,7 @@ pub mod pallet {
                     };
 
                     let state_root_inner = state_root.clone().into_inner();
-                    let msg = create_attestation_message(state_root_inner, block_number);
+                    let msg = create_attestation_message(state_root_inner, attested_block_number);
 
                     pallet_keystore::Pallet::<T>::verify_ethereum_msg(
                         &who,
@@ -197,16 +199,19 @@ pub mod pallet {
                         &signature,
                     )?;
 
-                    let mut attestations_for_block = Attestations::<T>::get(block_number);
+                    let mut attestations_for_block = Attestations::<T>::get(attested_block_number);
 
                     attestations_for_block
                         .try_push(attestation.clone())
                         .map_err(|_| Error::<T>::MaxAttestationsForBlockError)?;
 
-                    Attestations::<T>::insert(block_number, attestations_for_block);
+                    Attestations::<T>::insert(
+                        block_number.unwrap_or(current_block),
+                        attestations_for_block,
+                    );
 
                     Self::deposit_event(Event::<T>::BlockAttested {
-                        block_number,
+                        block_number: block_number.unwrap_or(current_block),
                         attestation,
                         who,
                     });

--- a/pallets/attestation/src/tests.rs
+++ b/pallets/attestation/src/tests.rs
@@ -101,7 +101,7 @@ fn attest_block_success() {
         // Submit the attestation.
         assert_ok!(Pallet::<Test>::attest_block(
             RuntimeOrigin::signed(account_id),
-            block_number,
+            Some(block_number),
             attestation.clone()
         ));
 
@@ -110,6 +110,79 @@ fn attest_block_success() {
         assert!(attestations
             .iter()
             .any(|stored_attestation| *stored_attestation == attestation));
+    });
+}
+
+#[test]
+fn attest_block_uses_current_block_by_default() {
+    new_test_ext().execute_with(|| {
+        System::set_block_number(15);
+        let account_id: u64 = 1;
+        let block_number: u32 = 10;
+
+        // Generate a keypair and create a signed message.
+        let (private_key, public_key, signature) = create_signed_message_and_keypair(account_id);
+
+        // Compute the address20 from the public key.
+        let address20 =
+            sxt_core::attestation::uncompressed_public_key_to_address(&public_key).unwrap();
+
+        // Register the attestation key for the account.
+        let registration = RegisterExternalAddress::EthereumAddress {
+            signature,
+            proposed_pub_key: public_key,
+            address20: address20.clone(),
+        };
+
+        assert_ok!(Keystore::register_key(
+            RuntimeOrigin::root(),
+            account_id,
+            registration
+        ));
+
+        let permissions = PermissionList::try_from(vec![PermissionLevel::AttestationPallet(
+            AttestationPalletPermission::AttestBlock,
+        )])
+        .unwrap();
+        assert_ok!(Permissions::set_permissions(
+            RuntimeOrigin::root(),
+            account_id,
+            permissions
+        ));
+
+        // Create an attestation using the same signature and public key.
+        let data: Vec<u8> = vec![0xFF; 64];
+
+        // Convert to BoundedVec<u8, ConstU32<64>>
+        let state_root = BoundedVec::try_from(data).expect("Should fit");
+        let attestation_message =
+            create_attestation_message(state_root.clone().into_inner(), block_number);
+        let attestation_signature = sign_eth_message(&private_key.to_bytes(), &attestation_message)
+            .expect("could not sign");
+
+        let attestation = Attestation::EthereumAttestation {
+            signature: attestation_signature,
+            proposed_pub_key: public_key,
+            address20,
+            state_root,
+            block_number,
+            block_hash: H256::zero(),
+        };
+
+        // Submit the attestation.
+        assert_ok!(Pallet::<Test>::attest_block(
+            RuntimeOrigin::signed(account_id),
+            None,
+            attestation.clone()
+        ));
+
+        // Verify that the attestation is stored in the current block, not the attested block
+        let attestations = Pallet::<Test>::attestations(15);
+        assert!(attestations
+            .iter()
+            .any(|stored_attestation| *stored_attestation == attestation));
+
+        assert!(Pallet::<Test>::attestations(10).is_empty());
     });
 }
 
@@ -139,7 +212,7 @@ fn attest_block_fails_if_account_not_registered() {
         assert_err!(
             Pallet::<Test>::attest_block(
                 RuntimeOrigin::signed(account_id),
-                block_number,
+                Some(block_number),
                 attestation
             ),
             pallet_permissions::Error::<Test>::InsufficientPermissions
@@ -202,14 +275,14 @@ fn attest_block_succeeds_with_multiple_attestations() {
         // Submit the attestation.
         assert_ok!(Pallet::<Test>::attest_block(
             RuntimeOrigin::signed(account_id),
-            block_number,
+            Some(block_number),
             attestation.clone()
         ));
 
         // Attempt to submit the same attestation again.
         assert_ok!(Pallet::<Test>::attest_block(
             RuntimeOrigin::signed(account_id),
-            block_number,
+            Some(block_number),
             attestation
         ));
     });
@@ -262,7 +335,7 @@ fn attest_block_fails_if_future_block() {
         assert_err!(
             Pallet::<Test>::attest_block(
                 RuntimeOrigin::signed(account_id),
-                future_block_number,
+                Some(future_block_number),
                 attestation
             ),
             Error::<Test>::CannotAttestFutureBlock

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -166,7 +166,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 236,
+    spec_version: 237,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/sxt-core/src/sxt_chain_runtime.rs
+++ b/sxt-core/src/sxt_chain_runtime.rs
@@ -1908,10 +1908,10 @@ pub mod api {
                         "query_call_info",
                         types::QueryCallInfo { call, len },
                         [
-                            231u8, 63u8, 233u8, 207u8, 155u8, 123u8, 102u8, 6u8, 143u8, 126u8,
-                            21u8, 106u8, 42u8, 6u8, 125u8, 57u8, 77u8, 230u8, 100u8, 43u8, 159u8,
-                            162u8, 152u8, 244u8, 248u8, 6u8, 130u8, 131u8, 255u8, 149u8, 198u8,
-                            80u8,
+                            115u8, 199u8, 216u8, 24u8, 216u8, 128u8, 101u8, 15u8, 32u8, 108u8,
+                            176u8, 37u8, 236u8, 10u8, 230u8, 224u8, 87u8, 148u8, 71u8, 218u8,
+                            104u8, 179u8, 30u8, 215u8, 10u8, 43u8, 89u8, 136u8, 178u8, 60u8, 24u8,
+                            175u8,
                         ],
                     )
                 }
@@ -1929,10 +1929,9 @@ pub mod api {
                         "query_call_fee_details",
                         types::QueryCallFeeDetails { call, len },
                         [
-                            11u8, 3u8, 135u8, 166u8, 119u8, 180u8, 132u8, 123u8, 178u8, 125u8,
-                            65u8, 105u8, 90u8, 212u8, 28u8, 62u8, 50u8, 6u8, 221u8, 49u8, 228u8,
-                            153u8, 10u8, 229u8, 203u8, 88u8, 112u8, 201u8, 236u8, 203u8, 250u8,
-                            3u8,
+                            89u8, 81u8, 65u8, 225u8, 225u8, 179u8, 181u8, 52u8, 89u8, 178u8, 78u8,
+                            98u8, 234u8, 96u8, 130u8, 237u8, 171u8, 38u8, 248u8, 4u8, 183u8, 21u8,
+                            18u8, 91u8, 112u8, 236u8, 148u8, 232u8, 180u8, 220u8, 142u8, 47u8,
                         ],
                     )
                 }
@@ -2739,9 +2738,9 @@ pub mod api {
             .hash();
         runtime_metadata_hash
             == [
-                180u8, 146u8, 94u8, 30u8, 4u8, 8u8, 111u8, 128u8, 140u8, 102u8, 185u8, 107u8, 37u8,
-                220u8, 155u8, 254u8, 54u8, 183u8, 177u8, 206u8, 16u8, 51u8, 246u8, 101u8, 13u8,
-                250u8, 239u8, 75u8, 85u8, 33u8, 242u8, 213u8,
+                160u8, 236u8, 242u8, 222u8, 13u8, 38u8, 225u8, 44u8, 208u8, 85u8, 43u8, 173u8,
+                76u8, 248u8, 165u8, 186u8, 15u8, 10u8, 110u8, 56u8, 166u8, 119u8, 37u8, 59u8, 83u8,
+                103u8, 21u8, 40u8, 41u8, 100u8, 195u8, 198u8,
             ]
     }
     pub mod system {
@@ -4491,10 +4490,9 @@ pub mod api {
                         "batch",
                         types::Batch { calls },
                         [
-                            236u8, 37u8, 234u8, 169u8, 219u8, 183u8, 167u8, 222u8, 194u8, 193u8,
-                            99u8, 173u8, 49u8, 118u8, 131u8, 140u8, 228u8, 250u8, 29u8, 202u8,
-                            117u8, 145u8, 42u8, 2u8, 136u8, 22u8, 117u8, 129u8, 79u8, 176u8, 206u8,
-                            158u8,
+                            47u8, 209u8, 43u8, 104u8, 170u8, 206u8, 5u8, 152u8, 72u8, 113u8, 171u8,
+                            129u8, 108u8, 21u8, 5u8, 182u8, 175u8, 125u8, 203u8, 207u8, 197u8,
+                            132u8, 233u8, 222u8, 88u8, 26u8, 161u8, 65u8, 74u8, 55u8, 137u8, 233u8,
                         ],
                     )
                 }
@@ -4525,9 +4523,10 @@ pub mod api {
                             call: ::subxt::ext::subxt_core::alloc::boxed::Box::new(call),
                         },
                         [
-                            93u8, 156u8, 65u8, 178u8, 178u8, 66u8, 23u8, 195u8, 70u8, 72u8, 171u8,
-                            9u8, 159u8, 203u8, 37u8, 47u8, 123u8, 9u8, 80u8, 112u8, 117u8, 8u8,
-                            220u8, 226u8, 122u8, 76u8, 230u8, 33u8, 5u8, 132u8, 38u8, 252u8,
+                            152u8, 239u8, 25u8, 222u8, 18u8, 120u8, 218u8, 145u8, 221u8, 1u8,
+                            143u8, 202u8, 22u8, 82u8, 139u8, 119u8, 219u8, 57u8, 153u8, 122u8,
+                            218u8, 16u8, 77u8, 67u8, 250u8, 45u8, 201u8, 148u8, 147u8, 11u8, 172u8,
+                            84u8,
                         ],
                     )
                 }
@@ -4554,9 +4553,9 @@ pub mod api {
                         "batch_all",
                         types::BatchAll { calls },
                         [
-                            165u8, 240u8, 74u8, 169u8, 10u8, 192u8, 169u8, 33u8, 215u8, 7u8, 48u8,
-                            139u8, 197u8, 138u8, 247u8, 187u8, 189u8, 10u8, 157u8, 33u8, 136u8,
-                            85u8, 48u8, 85u8, 159u8, 192u8, 202u8, 109u8, 162u8, 98u8, 87u8, 134u8,
+                            1u8, 176u8, 76u8, 116u8, 80u8, 234u8, 153u8, 190u8, 151u8, 16u8, 97u8,
+                            47u8, 1u8, 247u8, 158u8, 39u8, 107u8, 11u8, 58u8, 153u8, 239u8, 219u8,
+                            235u8, 21u8, 36u8, 89u8, 107u8, 17u8, 165u8, 8u8, 175u8, 193u8,
                         ],
                     )
                 }
@@ -4580,9 +4579,10 @@ pub mod api {
                             call: ::subxt::ext::subxt_core::alloc::boxed::Box::new(call),
                         },
                         [
-                            48u8, 166u8, 243u8, 188u8, 5u8, 250u8, 205u8, 208u8, 85u8, 232u8,
-                            218u8, 57u8, 4u8, 234u8, 122u8, 246u8, 65u8, 19u8, 251u8, 210u8, 239u8,
-                            91u8, 243u8, 155u8, 8u8, 83u8, 27u8, 160u8, 15u8, 175u8, 127u8, 213u8,
+                            240u8, 172u8, 70u8, 254u8, 66u8, 66u8, 18u8, 180u8, 80u8, 157u8, 251u8,
+                            91u8, 227u8, 122u8, 191u8, 165u8, 196u8, 19u8, 104u8, 213u8, 181u8,
+                            215u8, 83u8, 140u8, 136u8, 135u8, 251u8, 233u8, 145u8, 66u8, 131u8,
+                            192u8,
                         ],
                     )
                 }
@@ -4609,10 +4609,10 @@ pub mod api {
                         "force_batch",
                         types::ForceBatch { calls },
                         [
-                            97u8, 113u8, 197u8, 248u8, 12u8, 23u8, 229u8, 127u8, 38u8, 154u8,
-                            107u8, 9u8, 142u8, 165u8, 100u8, 232u8, 111u8, 40u8, 94u8, 148u8,
-                            238u8, 195u8, 72u8, 59u8, 28u8, 154u8, 35u8, 238u8, 254u8, 46u8, 15u8,
-                            203u8,
+                            100u8, 138u8, 162u8, 197u8, 226u8, 23u8, 192u8, 24u8, 89u8, 46u8,
+                            170u8, 92u8, 194u8, 171u8, 170u8, 186u8, 254u8, 204u8, 83u8, 24u8,
+                            230u8, 180u8, 199u8, 75u8, 206u8, 98u8, 236u8, 191u8, 169u8, 145u8,
+                            51u8, 171u8,
                         ],
                     )
                 }
@@ -4636,10 +4636,9 @@ pub mod api {
                             weight,
                         },
                         [
-                            89u8, 146u8, 134u8, 25u8, 60u8, 104u8, 167u8, 14u8, 234u8, 225u8,
-                            139u8, 32u8, 101u8, 116u8, 48u8, 224u8, 161u8, 172u8, 126u8, 10u8,
-                            223u8, 113u8, 36u8, 143u8, 55u8, 24u8, 160u8, 219u8, 191u8, 255u8,
-                            137u8, 63u8,
+                            80u8, 184u8, 7u8, 124u8, 58u8, 57u8, 40u8, 160u8, 21u8, 121u8, 61u8,
+                            206u8, 11u8, 201u8, 240u8, 153u8, 139u8, 225u8, 0u8, 212u8, 85u8,
+                            243u8, 233u8, 243u8, 122u8, 63u8, 60u8, 75u8, 63u8, 225u8, 237u8, 87u8,
                         ],
                     )
                 }
@@ -14962,10 +14961,9 @@ pub mod api {
                             call: ::subxt::ext::subxt_core::alloc::boxed::Box::new(call),
                         },
                         [
-                            117u8, 96u8, 69u8, 188u8, 58u8, 113u8, 92u8, 102u8, 195u8, 72u8, 104u8,
-                            235u8, 218u8, 96u8, 246u8, 203u8, 129u8, 200u8, 30u8, 189u8, 172u8,
-                            132u8, 31u8, 36u8, 12u8, 184u8, 203u8, 107u8, 234u8, 238u8, 107u8,
-                            165u8,
+                            133u8, 77u8, 168u8, 172u8, 220u8, 105u8, 230u8, 168u8, 139u8, 232u8,
+                            79u8, 16u8, 228u8, 233u8, 110u8, 135u8, 143u8, 1u8, 217u8, 44u8, 215u8,
+                            179u8, 73u8, 165u8, 9u8, 216u8, 10u8, 65u8, 151u8, 198u8, 187u8, 72u8,
                         ],
                     )
                 }
@@ -14988,10 +14986,9 @@ pub mod api {
                             weight,
                         },
                         [
-                            139u8, 49u8, 216u8, 114u8, 140u8, 230u8, 172u8, 192u8, 196u8, 207u8,
-                            250u8, 28u8, 154u8, 189u8, 128u8, 152u8, 18u8, 150u8, 118u8, 171u8,
-                            61u8, 12u8, 79u8, 35u8, 240u8, 195u8, 251u8, 39u8, 61u8, 159u8, 143u8,
-                            96u8,
+                            219u8, 62u8, 153u8, 124u8, 75u8, 217u8, 48u8, 115u8, 90u8, 104u8,
+                            115u8, 186u8, 35u8, 144u8, 93u8, 146u8, 23u8, 11u8, 100u8, 92u8, 150u8,
+                            245u8, 147u8, 229u8, 32u8, 0u8, 226u8, 188u8, 69u8, 201u8, 202u8, 35u8,
                         ],
                     )
                 }
@@ -15031,10 +15028,9 @@ pub mod api {
                             call: ::subxt::ext::subxt_core::alloc::boxed::Box::new(call),
                         },
                         [
-                            188u8, 202u8, 33u8, 105u8, 189u8, 184u8, 172u8, 140u8, 129u8, 127u8,
-                            234u8, 34u8, 178u8, 164u8, 93u8, 48u8, 195u8, 104u8, 93u8, 134u8,
-                            177u8, 137u8, 43u8, 149u8, 34u8, 232u8, 228u8, 253u8, 158u8, 226u8,
-                            186u8, 110u8,
+                            122u8, 141u8, 31u8, 17u8, 42u8, 116u8, 62u8, 208u8, 67u8, 79u8, 129u8,
+                            93u8, 44u8, 217u8, 237u8, 144u8, 5u8, 9u8, 78u8, 176u8, 6u8, 102u8,
+                            101u8, 223u8, 250u8, 184u8, 150u8, 238u8, 80u8, 123u8, 209u8, 57u8,
                         ],
                     )
                 }
@@ -16272,10 +16268,10 @@ pub mod api {
                             call: ::subxt::ext::subxt_core::alloc::boxed::Box::new(call),
                         },
                         [
-                            165u8, 126u8, 145u8, 112u8, 145u8, 122u8, 247u8, 229u8, 73u8, 192u8,
-                            168u8, 246u8, 201u8, 173u8, 124u8, 230u8, 95u8, 79u8, 232u8, 200u8,
-                            146u8, 194u8, 52u8, 200u8, 6u8, 77u8, 234u8, 139u8, 59u8, 35u8, 101u8,
-                            42u8,
+                            61u8, 144u8, 130u8, 174u8, 162u8, 228u8, 75u8, 165u8, 160u8, 48u8,
+                            141u8, 228u8, 111u8, 215u8, 40u8, 151u8, 225u8, 242u8, 191u8, 197u8,
+                            91u8, 56u8, 244u8, 227u8, 184u8, 214u8, 184u8, 163u8, 176u8, 79u8,
+                            193u8, 141u8,
                         ],
                     )
                 }
@@ -16338,9 +16334,10 @@ pub mod api {
                             max_weight,
                         },
                         [
-                            39u8, 237u8, 27u8, 101u8, 190u8, 9u8, 143u8, 206u8, 76u8, 60u8, 95u8,
-                            66u8, 237u8, 172u8, 42u8, 227u8, 84u8, 25u8, 172u8, 186u8, 83u8, 241u8,
-                            220u8, 149u8, 254u8, 201u8, 58u8, 58u8, 251u8, 56u8, 67u8, 55u8,
+                            172u8, 179u8, 215u8, 224u8, 175u8, 201u8, 190u8, 30u8, 200u8, 5u8,
+                            19u8, 187u8, 200u8, 157u8, 140u8, 214u8, 108u8, 133u8, 196u8, 66u8,
+                            125u8, 228u8, 56u8, 45u8, 79u8, 214u8, 14u8, 210u8, 94u8, 206u8, 117u8,
+                            108u8,
                         ],
                     )
                 }
@@ -20196,7 +20193,7 @@ pub mod api {
                 #[doc = "Submit a block attestation."]
                 #[doc = ""]
                 #[doc = "# Arguments"]
-                #[doc = "* `block_number` - The block being attested."]
+                #[doc = "* `block_number` - The block being attested. If not provided, uses the current block."]
                 #[doc = "* `attestation` - The attestation details."]
                 #[doc = ""]
                 #[doc = "# Emits"]
@@ -20206,14 +20203,13 @@ pub mod api {
                 #[doc = "* [`Error::CannotAttestFutureBlock`]"]
                 #[doc = "* [`Error::CannotAttestCurrentBlock`]"]
                 #[doc = "* [`Error::MaxAttestationsForBlockError`]"]
-                #[doc = "* [`Error::AttestationAlreadyRecordedError`]"]
                 pub struct AttestBlock {
                     pub block_number: attest_block::BlockNumber,
                     pub attestation: attest_block::Attestation,
                 }
                 pub mod attest_block {
                     use super::runtime_types;
-                    pub type BlockNumber = ::core::primitive::u32;
+                    pub type BlockNumber = ::core::option::Option<::core::primitive::u32>;
                     pub type Attestation = runtime_types::sxt_core::attestation::Attestation<
                         ::subxt::ext::subxt_core::utils::H256,
                     >;
@@ -20282,7 +20278,7 @@ pub mod api {
                 #[doc = "Submit a block attestation."]
                 #[doc = ""]
                 #[doc = "# Arguments"]
-                #[doc = "* `block_number` - The block being attested."]
+                #[doc = "* `block_number` - The block being attested. If not provided, uses the current block."]
                 #[doc = "* `attestation` - The attestation details."]
                 #[doc = ""]
                 #[doc = "# Emits"]
@@ -20292,7 +20288,6 @@ pub mod api {
                 #[doc = "* [`Error::CannotAttestFutureBlock`]"]
                 #[doc = "* [`Error::CannotAttestCurrentBlock`]"]
                 #[doc = "* [`Error::MaxAttestationsForBlockError`]"]
-                #[doc = "* [`Error::AttestationAlreadyRecordedError`]"]
                 pub fn attest_block(
                     &self,
                     block_number: types::attest_block::BlockNumber,
@@ -20307,9 +20302,9 @@ pub mod api {
                             attestation,
                         },
                         [
-                            254u8, 213u8, 43u8, 252u8, 176u8, 227u8, 13u8, 50u8, 126u8, 38u8, 33u8,
-                            181u8, 34u8, 66u8, 194u8, 196u8, 122u8, 107u8, 70u8, 196u8, 83u8, 43u8,
-                            111u8, 231u8, 202u8, 185u8, 205u8, 227u8, 19u8, 15u8, 153u8, 117u8,
+                            50u8, 19u8, 53u8, 249u8, 64u8, 98u8, 11u8, 15u8, 104u8, 219u8, 57u8,
+                            88u8, 52u8, 27u8, 159u8, 9u8, 99u8, 235u8, 207u8, 49u8, 38u8, 36u8,
+                            223u8, 150u8, 131u8, 26u8, 67u8, 247u8, 65u8, 50u8, 105u8, 215u8,
                         ],
                     )
                 }
@@ -23244,7 +23239,7 @@ pub mod api {
                     #[doc = "Submit a block attestation."]
                     #[doc = ""]
                     #[doc = "# Arguments"]
-                    #[doc = "* `block_number` - The block being attested."]
+                    #[doc = "* `block_number` - The block being attested. If not provided, uses the current block."]
                     #[doc = "* `attestation` - The attestation details."]
                     #[doc = ""]
                     #[doc = "# Emits"]
@@ -23254,9 +23249,8 @@ pub mod api {
                     #[doc = "* [`Error::CannotAttestFutureBlock`]"]
                     #[doc = "* [`Error::CannotAttestCurrentBlock`]"]
                     #[doc = "* [`Error::MaxAttestationsForBlockError`]"]
-                    #[doc = "* [`Error::AttestationAlreadyRecordedError`]"]
                     attest_block {
-                        block_number: ::core::primitive::u32,
+                        block_number: ::core::option::Option<::core::primitive::u32>,
                         attestation: runtime_types::sxt_core::attestation::Attestation<
                             ::subxt::ext::subxt_core::utils::H256,
                         >,

--- a/watcher/src/main.rs
+++ b/watcher/src/main.rs
@@ -537,7 +537,12 @@ impl AttestationClient {
 
                 let signature = generate_signature(private_key, &message)?;
 
-                Ok((signature, partial_message, None))
+                Ok((
+                    signature,
+                    partial_message,
+                    None,
+                    claimed_unstake.claim_block_number,
+                ))
             })
             .collect::<Result<Vec<_>, AttestationError>>()
             .inspect_err(|e| log::error!("Error generating signature: {}", e))
@@ -547,11 +552,21 @@ impl AttestationClient {
 
         let block = &block;
         futures::stream::iter(
-            std::iter::once((signature, partial_message, Some(block.number())))
-                .chain(claimed_unstake_signatures_and_roots),
+            std::iter::once((
+                signature,
+                partial_message,
+                Some(block.number()),
+                block.number(),
+            ))
+            .chain(claimed_unstake_signatures_and_roots),
         )
         .for_each(
-            |(signature, partial_message, attestation_key_block_number)| async move {
+            |(
+                signature,
+                partial_message,
+                attestation_key_block_number,
+                attestation_block_number,
+            )| async move {
                 if let Err(e) = self
                     .submit_transaction_with_retry(
                         block,
@@ -559,6 +574,7 @@ impl AttestationClient {
                         signature,
                         partial_message,
                         attestation_key_block_number,
+                        attestation_block_number,
                     )
                     .await
                 {
@@ -578,11 +594,17 @@ impl AttestationClient {
         signature: EthereumSignature,
         partial_message: Vec<u8>,
         attestation_key_block_number: Option<u32>,
+        attestation_block_number: u32,
     ) -> Result<(), AttestationError> {
         let header = block.header();
 
-        let attestation =
-            create_attestation(header, private_key, signature, partial_message.clone())?;
+        let attestation = create_attestation(
+            header,
+            private_key,
+            signature,
+            partial_message.clone(),
+            attestation_block_number,
+        )?;
 
         let tx = runtime::api::tx()
             .attestations()
@@ -615,12 +637,12 @@ fn create_attestation(
     private_key: &SigningKey,
     signature: EthereumSignature,
     state_root: Vec<u8>,
+    attestation_block_number: u32,
 ) -> Result<runtime::api::runtime_types::sxt_core::attestation::Attestation<H256>, AttestationError>
 {
     let sxt_core::attestation::EthereumSignature { r, s, v } = signature;
     let proposed_pub_key = get_proposed_pub_key(private_key)?;
 
-    let block_number = header.number;
     let block_hash = header.hash();
 
     let address20 = sxt_core::attestation::uncompressed_public_key_to_address(&proposed_pub_key)?;
@@ -636,7 +658,7 @@ fn create_attestation(
             proposed_pub_key,
             state_root: BoundedVec(state_root),
             address20,
-            block_number,
+            block_number: attestation_block_number,
             block_hash,
         },
     )

--- a/watcher/src/main.rs
+++ b/watcher/src/main.rs
@@ -537,7 +537,7 @@ impl AttestationClient {
 
                 let signature = generate_signature(private_key, &message)?;
 
-                Ok((signature, partial_message))
+                Ok((signature, partial_message, None))
             })
             .collect::<Result<Vec<_>, AttestationError>>()
             .inspect_err(|e| log::error!("Error generating signature: {}", e))
@@ -547,17 +547,25 @@ impl AttestationClient {
 
         let block = &block;
         futures::stream::iter(
-            std::iter::once((signature, partial_message))
+            std::iter::once((signature, partial_message, Some(block.number())))
                 .chain(claimed_unstake_signatures_and_roots),
         )
-        .for_each(|(signature, partial_message)| async move {
-            if let Err(e) = self
-                .submit_transaction_with_retry(block, private_key, signature, partial_message)
-                .await
-            {
-                log::info!("Error submitting tx: {:?}", e);
-            };
-        })
+        .for_each(
+            |(signature, partial_message, attestation_key_block_number)| async move {
+                if let Err(e) = self
+                    .submit_transaction_with_retry(
+                        block,
+                        private_key,
+                        signature,
+                        partial_message,
+                        attestation_key_block_number,
+                    )
+                    .await
+                {
+                    log::info!("Error submitting tx: {:?}", e);
+                };
+            },
+        )
         .await;
 
         Ok(())
@@ -569,6 +577,7 @@ impl AttestationClient {
         private_key: &SigningKey,
         signature: EthereumSignature,
         partial_message: Vec<u8>,
+        attestation_key_block_number: Option<u32>,
     ) -> Result<(), AttestationError> {
         let header = block.header();
 
@@ -577,7 +586,7 @@ impl AttestationClient {
 
         let tx = runtime::api::tx()
             .attestations()
-            .attest_block(block.number(), attestation);
+            .attest_block(attestation_key_block_number, attestation);
 
         match self
             .tx_submitter

--- a/watcher/src/main.rs
+++ b/watcher/src/main.rs
@@ -493,14 +493,13 @@ impl AttestationClient {
             fixed_size_state_root,
         );
 
-        let message = create_attestation_message(&partial_message, block.number());
-
-        let signature = match generate_signature(private_key, &message) {
-            Ok(sig) => sig,
-            Err(e) => {
-                log::error!("Error generating signature: {}", e);
-                return Ok(());
-            }
+        let Ok(commitments_attestation) =
+            create_attestation(block.hash(), private_key, partial_message, block.number())
+                .inspect_err(|e| {
+                    log::error!("Error generating attestation for commitments: {}", e)
+                })
+        else {
+            return Ok(());
         };
 
         // claimed_unstakes are currently the subxt type, not the core type.
@@ -530,58 +529,36 @@ impl AttestationClient {
                 // Should be a noop, but the consistency is nice
                 let partial_message = encode_domain_and_state_root(None, root_hash);
 
-                let message = create_attestation_message(
-                    partial_message.clone(),
-                    claimed_unstake.claim_block_number,
-                );
-
-                let signature = generate_signature(private_key, &message)?;
-
-                Ok((
-                    signature,
+                let attestation = create_attestation(
+                    block.hash(),
+                    private_key,
                     partial_message,
-                    None,
                     claimed_unstake.claim_block_number,
-                ))
+                )?;
+
+                Ok((attestation, None))
             })
             .collect::<Result<Vec<_>, AttestationError>>()
-            .inspect_err(|e| log::error!("Error generating signature: {}", e))
+            .inspect_err(|e| {
+                log::error!("Error generating attestation for claimed unstake: {}", e)
+            })
         else {
             return Ok(());
         };
 
         let block = &block;
         futures::stream::iter(
-            std::iter::once((
-                signature,
-                partial_message,
-                Some(block.number()),
-                block.number(),
-            ))
-            .chain(claimed_unstake_signatures_and_roots),
+            std::iter::once((commitments_attestation, Some(block.number())))
+                .chain(claimed_unstake_signatures_and_roots),
         )
-        .for_each(
-            |(
-                signature,
-                partial_message,
-                attestation_key_block_number,
-                attestation_block_number,
-            )| async move {
-                if let Err(e) = self
-                    .submit_transaction_with_retry(
-                        block,
-                        private_key,
-                        signature,
-                        partial_message,
-                        attestation_key_block_number,
-                        attestation_block_number,
-                    )
-                    .await
-                {
-                    log::info!("Error submitting tx: {:?}", e);
-                };
-            },
-        )
+        .for_each(|(attestation, attestation_key_block_number)| async move {
+            if let Err(e) = self
+                .submit_transaction_with_retry(block, attestation_key_block_number, attestation)
+                .await
+            {
+                log::info!("Error submitting tx: {:?}", e);
+            };
+        })
         .await;
 
         Ok(())
@@ -590,22 +567,9 @@ impl AttestationClient {
     async fn submit_transaction_with_retry(
         &self,
         block: &BlockT<PolkadotConfig, OnlineClient<SxtConfig>>,
-        private_key: &SigningKey,
-        signature: EthereumSignature,
-        partial_message: Vec<u8>,
         attestation_key_block_number: Option<u32>,
-        attestation_block_number: u32,
+        attestation: runtime::api::runtime_types::sxt_core::attestation::Attestation<H256>,
     ) -> Result<(), AttestationError> {
-        let header = block.header();
-
-        let attestation = create_attestation(
-            header,
-            private_key,
-            signature,
-            partial_message.clone(),
-            attestation_block_number,
-        )?;
-
         let tx = runtime::api::tx()
             .attestations()
             .attest_block(attestation_key_block_number, attestation);
@@ -633,17 +597,16 @@ impl AttestationClient {
 }
 
 fn create_attestation(
-    header: &SubstrateHeader<u32, BlakeTwo256>,
+    block_hash: H256,
     private_key: &SigningKey,
-    signature: EthereumSignature,
-    state_root: Vec<u8>,
+    partial_message: Vec<u8>,
     attestation_block_number: u32,
 ) -> Result<runtime::api::runtime_types::sxt_core::attestation::Attestation<H256>, AttestationError>
 {
-    let sxt_core::attestation::EthereumSignature { r, s, v } = signature;
-    let proposed_pub_key = get_proposed_pub_key(private_key)?;
+    let message = create_attestation_message(partial_message.clone(), attestation_block_number);
 
-    let block_hash = header.hash();
+    let EthereumSignature { r, s, v } = generate_signature(private_key, &message)?;
+    let proposed_pub_key = get_proposed_pub_key(private_key)?;
 
     let address20 = sxt_core::attestation::uncompressed_public_key_to_address(&proposed_pub_key)?;
     let address20 = BoundedVec(address20.as_slice().to_vec());
@@ -656,7 +619,7 @@ fn create_attestation(
                 v,
             },
             proposed_pub_key,
-            state_root: BoundedVec(state_root),
+            state_root: BoundedVec(partial_message),
             address20,
             block_number: attestation_block_number,
             block_hash,


### PR DESCRIPTION
# Rationale for this change
There are a couple issues related to block number causing the claimed unstake attestations to not work properly at the moment. This is in large part because there are now many block numbers at play in the flow, and some mistakes were made in their usage. These are..
* `A` The block being processed by the attestor
* `B` The block where the claim was actually done
* `C` The block that the attestation txn is inserted into
* `D` The block that is encoded in the message that the attestor signs
* `E` The block in the EthereumAttestation
* `F` The key of the Attestations StorageMap.

In the current design for claimed unstake attestations, we want `B = D = E < F = A = C`. However, due to some mistakes, we currently have `B = D = F < A = E < C`. This makes a couple changes in an attempt to correct this flow. See commit messages for more details.

# What changes are included in this PR?
- **feat: make block number optional in attest_block extrinsic**
- **fix: attest in current block for claimed unstakes**
- **fix: always use the attested block number in attestation struct**
- **refactor: generate attestation signatures in create_attestation**
- **feat: increment runtime spec version to 237**

# Are these changes tested?
Partially, the attestor code does not have a great testing framework at the moment.
