### PR TITLE
fix: retrieve correct attestation list to update in attest_block

### DIFF
--- a/pallets/attestation/src/lib.rs
+++ b/pallets/attestation/src/lib.rs
@@ -199,7 +199,8 @@ pub mod pallet {
                         &signature,
                     )?;
 
-                    let mut attestations_for_block = Attestations::<T>::get(attested_block_number);
+                    let mut attestations_for_block =
+                        Attestations::<T>::get(block_number.unwrap_or(current_block));
 
                     attestations_for_block
                         .try_push(attestation.clone())

--- a/pallets/attestation/src/tests.rs
+++ b/pallets/attestation/src/tests.rs
@@ -283,8 +283,24 @@ fn attest_block_succeeds_with_multiple_attestations() {
         assert_ok!(Pallet::<Test>::attest_block(
             RuntimeOrigin::signed(account_id),
             Some(block_number),
-            attestation
+            attestation.clone()
         ));
+
+        // Attempt to submit the same attestation again.
+        assert_ok!(Pallet::<Test>::attest_block(
+            RuntimeOrigin::signed(account_id),
+            None,
+            attestation.clone()
+        ));
+
+        assert_eq!(crate::Attestations::<Test>::get(10).into_iter().count(), 2);
+        assert!(crate::Attestations::<Test>::get(10)
+            .into_iter()
+            .all(|actual_attestation| actual_attestation == attestation));
+        assert_eq!(crate::Attestations::<Test>::get(15).into_iter().count(), 1);
+        assert!(crate::Attestations::<Test>::get(15)
+            .into_iter()
+            .all(|actual_attestation| actual_attestation == attestation));
     });
 }
 


### PR DESCRIPTION
# Rationale for this change
The attest_block extrinsic needs to insert the attestation into the block that is either paramterized or the current block. While it is inserting the attestation into the correct storage key, it is not using the correct initial collection to insert to, instead grabbing the block number from the attestation struct.

# What changes are included in this PR?
Attestor retrieves parameterized/current block attestation collection to update instead of the attestation block.

# Are these changes tested?
Soon
