### PR TITLE
feat: increment runtime spec version to 238

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -166,7 +166,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 237,
+    spec_version: 238,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
# Rationale for this change
Recent bug fixes have been made to the attestation pallet, in particular the attest_block extrinsic. This change updates the runtime spec version accordingly

# Are these changes tested?
These changes do not affect existing functionality, which is verified by existing tests.
