### PR TITLE
fix: Add more unit tests to unstaking and make claims infallible

### DIFF
--- a/pallets/system_tables/src/lib.rs
+++ b/pallets/system_tables/src/lib.rs
@@ -359,45 +359,27 @@ pub mod pallet {
                         let staker_id =
                             sxt_core::utils::eth_address_to_substrate_account_id::<T>(&staker)?;
 
-                        // Make sure they're staked
-                        let Some(old_staking_ledger) = pallet_staking::Ledger::<T>::get(&staker_id)
-                        else {
-                            return Err(Error::<T>::AccountNotStaked.into());
-                        };
-
-                        // Make sure they're in an unbonding state
-                        if !(pallet_staking::Pallet::<T>::is_unbonding(&staker_id)?) {
-                            return Err(Error::<T>::AccountNotUnbonding.into());
-                        }
-
                         let staker_signer: OriginFor<T> =
                             RawOrigin::Signed(staker_id.clone()).into();
 
-                        // The struct that represents when a particular batch of funds will unlock
-                        // has all fields private to the staking crate. For now the
-                        // best we can do is to call the withdraw function and see if there are any
-                        // balance changes.
-                        pallet_staking::Pallet::<T>::withdraw_unbonded(staker_signer.clone(), 0u32)
-                            .map_err(|e| e.error)?;
-
-                        // Check if the user still has entries in the staking ledger
-                        let maybe_new_staking_ledger = pallet_staking::Ledger::<T>::get(&staker_id);
-
-                        if maybe_new_staking_ledger.is_some() {
-                            // If this was a partial unlock we need to actually check if the locks
-                            // were removed by the withdrawal call. If they weren't the claim is
-                            // unsuccessful and we return an error. Otherwise we emit the event
-                            if pallet_staking::Pallet::<T>::is_unbonding(&staker_id)? {
-                                // The user's unstaked funds are still locked
-                                return Err(Error::<T>::FundsLocked.into());
-                            }
-                        }
-
-                        let new_total = maybe_new_staking_ledger
+                        let old_total = pallet_staking::Ledger::<T>::get(&staker_id)
                             .map(|ledger| ledger.total)
                             .unwrap_or(0);
 
-                        let amount_withdrawn = old_staking_ledger.total.saturating_sub(new_total);
+                        // Even if the withdraw returns an error, we want to make sure we emit the
+                        // event and log that a claim was attempted. For now that means holding
+                        // onto the error
+                        let maybe_error = pallet_staking::Pallet::<T>::withdraw_unbonded(
+                            staker_signer.clone(),
+                            0u32,
+                        )
+                        .map_err(|e| e.error);
+
+                        let new_total = pallet_staking::Ledger::<T>::get(&staker_id)
+                            .map(|ledger| ledger.total)
+                            .unwrap_or(0);
+
+                        let amount_withdrawn = old_total.saturating_sub(new_total);
 
                         ClaimedUnstakes::<T>::insert(
                             &staker_id,
@@ -409,6 +391,10 @@ pub mod pallet {
                         Pallet::<T>::deposit_event(Event::<T>::UnstakingClaimed {
                             claimer: staker_id.clone(),
                         });
+
+                        // Now that we've logged the claim and emitted the event, return any
+                        // possible error so that it is emitted as an event
+                        maybe_error?;
 
                         // Burn the unbonded amount from the account
                         pallet_balances::Pallet::<T>::burn(
@@ -450,6 +436,22 @@ pub mod pallet {
                         // the amount to the available stake
                         let stake_amount = amount.min(&U256::from(u128::MAX)).low_u128();
                         let unstake_amount = stake_amount.min(staking_ledger.active);
+
+                        // How much will be active after the unbonding. Is it less than the
+                        let remaining_active = staking_ledger.active - unstake_amount;
+
+                        if let Some(nominations) = pallet_staking::Nominators::<T>::get(&staker_id)
+                        {
+                            if remaining_active < pallet_staking::MinNominatorBond::<T>::get() {
+                                pallet_staking::Pallet::<T>::chill(staker_signer.clone())?;
+                            }
+                        }
+
+                        if pallet_staking::Validators::<T>::contains_key(&staker_id)
+                            && remaining_active < pallet_staking::MinValidatorBond::<T>::get()
+                        {
+                            pallet_staking::Pallet::<T>::chill(staker_signer.clone())?;
+                        }
 
                         pallet_staking::Pallet::<T>::unbond(staker_signer, unstake_amount)
                             .map_err(|e| e.error)?;

--- a/pallets/system_tables/src/tests.rs
+++ b/pallets/system_tables/src/tests.rs
@@ -25,8 +25,15 @@ use sxt_core::utils::{
 use crate::mock::*;
 use crate::Pallet;
 
+/// Returns input * 10^18
+fn add_zeros(input: u128) -> u128 {
+    input.saturating_mul(1_000_000_000_000_000_000u128)
+}
+
 // Example SCALE encoded Session keys from calling author_rotateKeys() on Alice
 const ALICE_SESSION_KEYS: &str = "3084486e870e12fc551eacc173291f0d75ac5fed823aeb1e158bc98db215936202a555f88490d19f7fbacac7078fc87886084efd8227187a73ad05aee6da8ad38edd8739daa5689e9e118eb3be0330bbf80a30ad7639d4f0d70970dbccff9c4a";
+const ALICE_HEX_PUB_KEY: &str =
+    "0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d";
 const ETH_TEST_WALLET: &str = "44bCf7001D9C3fe8b7aA2BBaaf1B94410db31f5c";
 const EXPECTED_TRANSFORMED_ETH_TEST_WALLET_HEX: &str =
     "00000000000000000000000044bCf7001D9C3fe8b7aA2BBaaf1B94410db31f5c";
@@ -41,6 +48,24 @@ fn get_staked_message(wallet: &str, amount: U256) -> SystemRequest {
                 SystemFieldValue::Bytes(wallet_bytes),
             ),
             SystemTableField::with_value("AMOUNT".to_string(), SystemFieldValue::Decimal(amount)),
+        ],
+    }
+}
+
+fn get_nominate_message(wallet: &str, target: &Vec<&str>) -> SystemRequest {
+    let wallet_bytes = hex::decode(wallet).unwrap();
+    SystemRequest {
+        request_type: SystemRequestType::Staking(StakingSystemRequest::Nominate),
+        table_id: TableIdentifier::from_str_unchecked("NOMINATED", "SXT_SYSTEM_STAKING"),
+        fields: vec![
+            SystemTableField::with_value(
+                "NOMINATOR".to_string(),
+                SystemFieldValue::Bytes(wallet_bytes),
+            ),
+            SystemTableField::with_value(
+                "NODESED25519PUBKEYS".to_string(),
+                SystemFieldValue::Varchar(serde_json::to_string(target).unwrap()),
+            ),
         ],
     }
 }
@@ -231,6 +256,157 @@ fn set_session_keys_works_if_stash_is_bonded() {
         let wallet = eth_address_to_substrate_account_id::<Test>(ETH_TEST_WALLET).unwrap();
         assert!(pallet_staking::Validators::<Test>::contains_key(&wallet));
         assert!(pallet_session::NextKeys::<Test>::contains_key(&wallet));
+    });
+}
+
+#[test]
+fn set_nominations_works_if_stash_is_bonded() {
+    new_test_ext().execute_with(|| {
+        // We have to bond an amount to establish the stash/controller accounts
+        let test_amount = 100;
+        let bonding = get_staked_message(ETH_TEST_WALLET, test_amount.into());
+        assert_ok!(crate::process_staking::<Test>(bonding));
+
+        // Setup nominations for Alice
+        let nomination_targets = vec![ALICE_HEX_PUB_KEY];
+
+        let nominate = get_nominate_message(ETH_TEST_WALLET, &nomination_targets);
+        assert_ok!(crate::process_nominating::<Test>(nominate));
+        let found = pallet_staking::Nominators::<Test>::drain().any(|(nominator, _)| true);
+
+        assert!(found, "Expected nominator not found in staking nominators");
+    });
+}
+
+#[test]
+fn set_nominations_fails_if_stash_is_not_bonded_first() {
+    new_test_ext().execute_with(|| {
+        System::set_block_number(1);
+        // Setup nominations for Alice
+
+        let nomination_targets = vec![ALICE_HEX_PUB_KEY];
+
+        let nominate = get_nominate_message(ETH_TEST_WALLET, &nomination_targets);
+        assert_ok!(crate::process_nominating::<Test>(nominate));
+
+        let events = System::events();
+        match events.last().map(|e| &e.event) {
+            Some(RuntimeEvent::SystemTables(crate::Event::MessageProcessingError { error })) => {
+                assert_eq!(
+                    error,
+                    &DispatchError::from(pallet_staking::Error::<Test>::NotController)
+                );
+            }
+            _ => panic!("Expected MessageProcessingError event not found"),
+        }
+    });
+}
+
+#[test]
+fn full_unstake_works_even_if_user_is_nominating() {
+    new_test_ext().execute_with(|| {
+        System::set_block_number(1);
+
+        let test_account = eth_address_to_substrate_account_id::<Test>(ETH_TEST_WALLET).unwrap();
+
+        // Ensure the minimum is set to 100 SXT
+        pallet_staking::MinNominatorBond::<Test>::set(add_zeros(100));
+        assert_eq!(Staking::minimum_nominator_bond(), add_zeros(100));
+
+        // We have to bond an amount to establish the stash/controller accounts
+        let test_amount = add_zeros(100);
+        let bonding = get_staked_message(ETH_TEST_WALLET, test_amount.into());
+        assert_ok!(crate::process_staking::<Test>(bonding));
+
+        // Assert that we bonded 100SXT and then reset the events
+        System::assert_has_event(RuntimeEvent::Staking(pallet_staking::Event::Bonded {
+            stash: test_account.clone(),
+            amount: test_amount,
+        }));
+        System::reset_events();
+
+        // Setup nominations for Alice
+        let nomination_targets = vec![ALICE_HEX_PUB_KEY];
+
+        let nominate = get_nominate_message(ETH_TEST_WALLET, &nomination_targets);
+        assert_ok!(crate::process_nominating::<Test>(nominate));
+        assert_eq!(
+            pallet_staking::Nominators::<Test>::get(test_account)
+                .unwrap()
+                .targets
+                .len(),
+            1
+        );
+
+        // Now try to fully unstake
+        let unstake = get_unstaked_message(ETH_TEST_WALLET, test_amount.into());
+        assert_ok!(crate::process_unstake_initiated::<Test>(unstake));
+
+        // Now we do lookups based on the converted address to assure that state is set correctly
+        let transformed_eth_wallet =
+            eth_address_to_substrate_account_id::<Test>(ETH_TEST_WALLET).unwrap();
+
+        // Check that the unbonded event was emitted with the correct values
+        System::assert_has_event(RuntimeEvent::Staking(
+            pallet_staking::Event::<Test>::Unbonded {
+                stash: transformed_eth_wallet,
+                amount: test_amount,
+            },
+        ));
+    });
+}
+
+#[test]
+fn unstaking_more_than_account_balance_succeeds_and_unbonds_available_balance_instead() {
+    new_test_ext().execute_with(|| {
+        System::set_block_number(1);
+
+        let test_account = eth_address_to_substrate_account_id::<Test>(ETH_TEST_WALLET).unwrap();
+
+        // Ensure the minimum is set to 100 SXT
+        pallet_staking::MinNominatorBond::<Test>::set(add_zeros(100));
+        assert_eq!(Staking::minimum_nominator_bond(), add_zeros(100));
+
+        // We have to bond an amount to establish the stash/controller accounts
+        let test_amount = add_zeros(100);
+        let bonding = get_staked_message(ETH_TEST_WALLET, test_amount.into());
+        assert_ok!(crate::process_staking::<Test>(bonding));
+
+        // Assert that we bonded 100SXT and then reset the events
+        System::assert_has_event(RuntimeEvent::Staking(pallet_staking::Event::Bonded {
+            stash: test_account.clone(),
+            amount: test_amount,
+        }));
+        System::reset_events();
+
+        // Setup nominations for Alice
+        let nomination_targets = vec![ALICE_HEX_PUB_KEY];
+
+        let nominate = get_nominate_message(ETH_TEST_WALLET, &nomination_targets);
+        assert_ok!(crate::process_nominating::<Test>(nominate));
+        assert_eq!(
+            pallet_staking::Nominators::<Test>::get(test_account)
+                .unwrap()
+                .targets
+                .len(),
+            1
+        );
+
+        // Now try to unstake DOUBLE the staked amount
+        let unstake = get_unstaked_message(ETH_TEST_WALLET, (test_amount * 2).into());
+        assert_ok!(crate::process_unstake_initiated::<Test>(unstake));
+
+        // Check that the unbonded event was emitted with the correct values
+        // indicating that only the available balance was unbonded
+        let transformed_eth_wallet =
+            eth_address_to_substrate_account_id::<Test>(ETH_TEST_WALLET).unwrap();
+
+        System::assert_has_event(RuntimeEvent::Staking(
+            pallet_staking::Event::<Test>::Unbonded {
+                stash: transformed_eth_wallet,
+                amount: test_amount,
+            },
+        ));
     });
 }
 

--- a/pallets/system_tables/src/tests.rs
+++ b/pallets/system_tables/src/tests.rs
@@ -303,6 +303,65 @@ fn set_nominations_fails_if_stash_is_not_bonded_first() {
 }
 
 #[test]
+fn initiate_unstake_fails_if_stash_is_not_bonded_first() {
+    new_test_ext().execute_with(|| {
+        System::set_block_number(1);
+        // Setup nominations for Alice
+
+        // Try to unstake 100 SXT without bonding first
+        let unstake = get_unstaked_message(ETH_TEST_WALLET, add_zeros(100).into());
+        assert_ok!(crate::process_unstake_initiated::<Test>(unstake));
+
+        let events = System::events();
+        match events.last().map(|e| &e.event) {
+            Some(RuntimeEvent::SystemTables(crate::Event::MessageProcessingError { error })) => {
+                assert_eq!(
+                    error,
+                    &DispatchError::from(pallet_staking::Error::<Test>::NotStash)
+                );
+            }
+            _ => panic!("Expected MessageProcessingError event not found"),
+        }
+    });
+}
+
+#[test]
+fn if_withdraw_unbonded_produces_error_during_claim_events_still_emit() {
+    new_test_ext().execute_with(|| {
+        System::set_block_number(1);
+        System::reset_events();
+
+        let transformed_eth_wallet =
+            eth_address_to_substrate_account_id::<Test>(ETH_TEST_WALLET).unwrap();
+
+        // Now we'll manually screw up the stash/controller relationship so that the
+        // withdraw_unbonded will fail
+        //       pallet_staking::StakingLedger::<Test>::set(transformed_eth_wallet, Default::default());
+
+        let claim = get_claim_unstake_message(ETH_TEST_WALLET);
+        assert_ok!(crate::process_unstake_claimed::<Test>(claim));
+
+        let maybe_claims: Vec<_> =
+            crate::ClaimedUnstakes::<Test>::iter_prefix(&transformed_eth_wallet).collect();
+
+        // Assert we have one pending claim
+        assert_eq!(maybe_claims.len(), 1);
+
+        // Now we want to see an event for the claim with an amount of 0
+        // and an event for the withdraw_unbonded error to prove it still threw one
+        System::assert_has_event(RuntimeEvent::SystemTables(crate::Event::UnstakingClaimed {
+            claimer: transformed_eth_wallet,
+        }));
+
+        System::assert_has_event(RuntimeEvent::SystemTables(
+            crate::Event::MessageProcessingError {
+                error: DispatchError::from(pallet_staking::Error::<Test>::NotController),
+            },
+        ));
+    });
+}
+
+#[test]
 fn full_unstake_works_even_if_user_is_nominating() {
     new_test_ext().execute_with(|| {
         System::set_block_number(1);
@@ -935,7 +994,7 @@ fn partial_unstaking_works_end_to_end_and_reduces_balance_when_claimed() {
 }
 
 #[test]
-fn attempting_to_claim_before_unbonding_period_produces_error() {
+fn attempting_to_claim_before_unbonding_period_emits_a_claim_event_without_balance_change() {
     new_test_ext().execute_with(|| {
         crate::mock::start_active_era(1);
         let test_amount = 100;
@@ -981,6 +1040,10 @@ fn attempting_to_claim_before_unbonding_period_produces_error() {
         let claim_unstake = get_claim_unstake_message(ETH_TEST_WALLET);
 
         assert_ok!(crate::process_unstake_claimed::<Test>(claim_unstake));
+
+        let claims: Vec<_> =
+            crate::ClaimedUnstakes::<Test>::iter_prefix(&transformed_eth_wallet).collect();
+        assert_eq!(claims.len(), 1);
 
         // Ensure a claim event for 0 was still emitted
         System::assert_has_event(RuntimeEvent::SystemTables(crate::Event::UnstakingClaimed {

--- a/pallets/system_tables/src/tests.rs
+++ b/pallets/system_tables/src/tests.rs
@@ -982,21 +982,10 @@ fn attempting_to_claim_before_unbonding_period_produces_error() {
 
         assert_ok!(crate::process_unstake_claimed::<Test>(claim_unstake));
 
-        assert!(Pallet::<Test>::claimed_unstakes().is_empty());
-
-        // Ensure there was an error emitted
-        System::assert_has_event(RuntimeEvent::SystemTables(
-            crate::Event::MessageProcessingError {
-                error: crate::Error::<Test>::FundsLocked.into(),
-            },
-        ));
-
-        System::reset_events();
-
-        // Make sure that even if we call unstake, we don't get the balance back
-        let unstaked = get_unstaked_message(ETH_TEST_WALLET, test_amount.into());
-        assert_ok!(crate::process_unstaked::<Test>(unstaked));
-        assert!(Pallet::<Test>::claimed_unstakes().is_empty());
+        // Ensure a claim event for 0 was still emitted
+        System::assert_has_event(RuntimeEvent::SystemTables(crate::Event::UnstakingClaimed {
+            claimer: transformed_eth_wallet,
+        }));
     });
 }
 


### PR DESCRIPTION
# Rationale for this change
Previously, we were lacking coverage of test cases involving nominations. This PR adds more unit tests around nominators as well as fixes a couple of logic points that were causing test failures.

# Are these changes tested?
Yes