### PR TITLE
feat: Add more functionality to Canary Service

### DIFF
--- a/canaries/src/main.rs
+++ b/canaries/src/main.rs
@@ -1,6 +1,7 @@
 //! Canary prototype
 mod metrics;
 mod parsing;
+mod storage;
 use std::net::SocketAddr;
 
 use clap::Parser;
@@ -17,12 +18,12 @@ use log::{error, info};
 use snafu::{ResultExt, Snafu};
 use subxt::events::EventDetails;
 use subxt::{OnlineClient, PolkadotConfig};
-use sxt_core::sxt_chain_runtime;
 use sxt_core::sxt_chain_runtime::api::session::events::NewSession;
 use url::Url;
 
 use crate::metrics::*;
 use crate::parsing::*;
+use crate::storage::*;
 
 /// Canary: Substrate Finalized Block Event Monitor
 #[derive(Debug, Parser)]
@@ -88,29 +89,16 @@ async fn main() -> Result<(), CanaryError> {
 struct DummyProcessor {
     annualizer: f64,
 }
-use std::collections::HashMap;
+
 #[async_trait::async_trait]
 impl BlockProcessor for DummyProcessor {
     async fn process_block(&mut self, _api: &API, block: Block) {
         let events = fetch_all_events(&block).await.unwrap_or_default();
 
-        // Count all the events in the block by their pallet and variant
-        let mut event_count = HashMap::<String, u64>::new();
-        for e in events.iter() {
-            let label = format!("{:?}-{:?}", e.pallet_name(), e.variant_name());
-            match event_count.get(&label) {
-                Some(count) => {
-                    event_count.insert(label, count + 1);
-                }
-                None => {
-                    event_count.insert(label, 1);
-                }
-            }
-        }
-
-        event_count.iter().for_each(|(label, count)| {
-            EVENT_COUNTER.with_label_values(&[label]).inc_by(*count);
-        });
+        // Parse the event names and record each one
+        parse_event_names(&events)
+            .iter()
+            .for_each(|name| record_event(name));
 
         count_reward_stats(&block, &events, _api, self.annualizer).await;
 
@@ -130,93 +118,27 @@ async fn count_reward_stats(
     api: &API,
     annualizer: f64,
 ) {
-    let session_events = filter_events::<NewSession>(&events);
-
-    if let Some(event) = session_events.first() {
-        let session_index = event.session_index;
-        info!("🧭 New session detected: {}", session_index);
-
-        let active_era_query = sxt_chain_runtime::api::storage().staking().active_era();
-        let active_era = match api
-            .storage()
-            .at(block.hash())
-            .fetch(&active_era_query)
-            .await
-        {
-            Ok(Some(info)) => info.index,
+    if let Some(new_session) = filter_events::<NewSession>(&events).first() {
+        match read_active_era(block, api).await {
+            Ok(Some(active)) => {
+                // We have an active era, so let's try to get rewards details
+                let prev_era = active.saturating_sub(1);
+                let label = &prev_era.to_string();
+                if let Ok(Some(rewards)) = read_era_rewards(prev_era, block, api).await {
+                    record_era_rewards(prev_era, rewards);
+                }
+                if let Ok(Some(total_staked)) = read_total_staked(prev_era, block, api).await {
+                    record_era_total_stake(prev_era, total_staked);
+                }
+            }
             Ok(None) => {
-                info!("No active era found at block {}", block.number());
-                return;
+                // There was no error retriving the era from the chain, but the current era was
+                // None
             }
             Err(e) => {
-                error!("❌ Failed to fetch active era: {:?}", e);
-                return;
+                log::error!("Error trying to retrieve active_era {e:?}");
             }
-        };
-
-        let prev_era = active_era.saturating_sub(1);
-
-        let era_reward_query = sxt_chain_runtime::api::storage()
-            .staking()
-            .eras_validator_reward(prev_era);
-        let era_reward = match api
-            .storage()
-            .at(block.hash())
-            .fetch(&era_reward_query)
-            .await
-        {
-            Ok(Some(val)) => val,
-            Ok(None) => {
-                info!("No reward data found for era {}", prev_era);
-                return;
-            }
-            Err(e) => {
-                error!("❌ Failed to fetch validator reward: {:?}", e);
-                return;
-            }
-        };
-
-        let total_staked_query = sxt_chain_runtime::api::storage()
-            .staking()
-            .eras_total_stake(prev_era);
-        let total_staked = match api
-            .storage()
-            .at(block.hash())
-            .fetch(&total_staked_query)
-            .await
-        {
-            Ok(Some(val)) => val,
-            Ok(None) => {
-                info!("No total stake found for era {}", prev_era);
-                return;
-            }
-            Err(e) => {
-                error!("❌ Failed to fetch total stake: {:?}", e);
-                return;
-            }
-        };
-
-        if total_staked == 0 {
-            info!("⚠️ Total stake for era {} is zero, skipping", prev_era);
-            return;
         }
-
-        let reward_rate = era_reward as f64 / total_staked as f64;
-        let annualized_rate = reward_rate * annualizer;
-
-        let era_label = &prev_era.to_string();
-
-        REWARD_RATE
-            .with_label_values(&[era_label])
-            .set(annualized_rate * 100.0);
-
-        TOTAL_STAKED
-            .with_label_values(&[era_label])
-            .set(total_staked as f64);
-        VALIDATOR_REWARD
-            .with_label_values(&[era_label])
-            .set(era_reward as f64);
-        ANNUALIZER.with_label_values(&[era_label]).set(annualizer);
     }
 }
 

--- a/canaries/src/main.rs
+++ b/canaries/src/main.rs
@@ -1,5 +1,6 @@
 //! Canary prototype
 mod metrics;
+mod parsing;
 use std::net::SocketAddr;
 
 use clap::Parser;
@@ -21,6 +22,7 @@ use sxt_core::sxt_chain_runtime::api::session::events::NewSession;
 use url::Url;
 
 use crate::metrics::*;
+use crate::parsing::*;
 
 /// Canary: Substrate Finalized Block Event Monitor
 #[derive(Debug, Parser)]
@@ -112,96 +114,14 @@ impl BlockProcessor for DummyProcessor {
 
         count_reward_stats(&block, &events, _api, self.annualizer).await;
 
-        count_staking_stats(&events);
-        count_balance_stats(&events);
+        parse_staking_stats(&events)
+            .iter()
+            .for_each(|(name, val)| record_staking(name, *val));
+
+        parse_balance_stats(&events)
+            .iter()
+            .for_each(|(name, val)| record_balance(name, *val));
     }
-}
-
-fn count_staking_stats(events: &Vec<EventDetails<PolkadotConfig>>) {
-    use sxt_core::sxt_chain_runtime::api::staking::events::{
-        Bonded,
-        Rewarded,
-        Slashed,
-        Unbonded,
-        Withdrawn,
-    };
-
-    events.iter().for_each(|event| {
-        if event.pallet_name().contains("Staking") {
-            if let Ok(Some(e)) = event.as_event::<Bonded>() {
-                record_staking(event.variant_name(), e.amount);
-            } else if let Ok(Some(e)) = event.as_event::<Unbonded>() {
-                record_staking(event.variant_name(), e.amount);
-            } else if let Ok(Some(e)) = event.as_event::<Withdrawn>() {
-                record_staking(event.variant_name(), e.amount);
-            } else if let Ok(Some(e)) = event.as_event::<Rewarded>() {
-                record_staking(event.variant_name(), e.amount);
-            } else if let Ok(Some(e)) = event.as_event::<Slashed>() {
-                record_staking(event.variant_name(), e.amount);
-            }
-        }
-    });
-}
-
-fn record_staking(label: &str, amount: u128) {
-    use subxt::ext::sp_runtime::SaturatedConversion;
-    STAKING_COUNTER
-        .with_label_values(&[label])
-        .inc_by(amount.saturated_into());
-}
-
-fn count_balance_stats(events: &Vec<EventDetails<PolkadotConfig>>) {
-    use sxt_core::sxt_chain_runtime::api::balances::events::{
-        Burned,
-        Frozen,
-        Issued,
-        Locked,
-        Minted,
-        Rescinded,
-        Reserved,
-        Thawed,
-        Transfer,
-        Unlocked,
-        Unreserved,
-    };
-    // Unfortunately Prometheus is natively using 64 bit numbers, so the best we can do  for
-    // balance handling is saturated_into and then make sure the time frame we look at on the
-    // dashboard is using the rate instead of the absolute total value
-    events.iter().for_each(|event| {
-        if event.pallet_name().contains("Balances") {
-            if let Ok(Some(e)) = event.as_event::<Issued>() {
-                record_balance("Issued", e.amount);
-            } else if let Ok(Some(e)) = event.as_event::<Burned>() {
-                record_balance("Burned", e.amount);
-            } else if let Ok(Some(e)) = event.as_event::<Unreserved>() {
-                record_balance("Unreserved", e.amount);
-            } else if let Ok(Some(e)) = event.as_event::<Frozen>() {
-                record_balance("Frozen", e.amount);
-            } else if let Ok(Some(e)) = event.as_event::<Thawed>() {
-                record_balance("Thawed", e.amount);
-            } else if let Ok(Some(e)) = event.as_event::<Locked>() {
-                record_balance("Locked", e.amount);
-            } else if let Ok(Some(e)) = event.as_event::<Minted>() {
-                record_balance("Minted", e.amount);
-            } else if let Ok(Some(e)) = event.as_event::<Reserved>() {
-                record_balance("Reserved", e.amount);
-            } else if let Ok(Some(e)) = event.as_event::<Transfer>() {
-                record_balance("Transfer", e.amount);
-            } else if let Ok(Some(e)) = event.as_event::<Unlocked>() {
-                record_balance("Unlocked", e.amount);
-            } else if let Ok(Some(e)) = event.as_event::<Rescinded>() {
-                record_balance("Rescinded", e.amount);
-            }
-        }
-    });
-}
-
-fn record_balance(label: &str, amount: u128) {
-    use subxt::ext::sp_runtime::SaturatedConversion;
-    log::info!("Recording balance label {label:?} with amount {amount:?}");
-    BALANCE_COUNTER
-        .with_label_values(&[label])
-        .inc_by(amount.saturated_into());
 }
 
 async fn count_reward_stats(

--- a/canaries/src/main.rs
+++ b/canaries/src/main.rs
@@ -95,7 +95,7 @@ impl BlockProcessor for DummyProcessor {
         // Count all the events in the block by their pallet and variant
         let mut event_count = HashMap::<String, u64>::new();
         for e in events.iter() {
-            let label = format!("{:?}.{:?}", e.pallet_name(), e.variant_name());
+            let label = format!("{:?}-{:?}", e.pallet_name(), e.variant_name());
             match event_count.get(&label) {
                 Some(count) => {
                     event_count.insert(label, count + 1);
@@ -112,8 +112,42 @@ impl BlockProcessor for DummyProcessor {
 
         count_reward_stats(&block, &events, _api, self.annualizer).await;
 
+        count_staking_stats(&events);
         count_balance_stats(&events);
     }
+}
+
+fn count_staking_stats(events: &Vec<EventDetails<PolkadotConfig>>) {
+    use sxt_core::sxt_chain_runtime::api::staking::events::{
+        Bonded,
+        Rewarded,
+        Slashed,
+        Unbonded,
+        Withdrawn,
+    };
+
+    events.iter().for_each(|event| {
+        if event.pallet_name().contains("Staking") {
+            if let Ok(Some(e)) = event.as_event::<Bonded>() {
+                record_staking(event.variant_name(), e.amount);
+            } else if let Ok(Some(e)) = event.as_event::<Unbonded>() {
+                record_staking(event.variant_name(), e.amount);
+            } else if let Ok(Some(e)) = event.as_event::<Withdrawn>() {
+                record_staking(event.variant_name(), e.amount);
+            } else if let Ok(Some(e)) = event.as_event::<Rewarded>() {
+                record_staking(event.variant_name(), e.amount);
+            } else if let Ok(Some(e)) = event.as_event::<Slashed>() {
+                record_staking(event.variant_name(), e.amount);
+            }
+        }
+    });
+}
+
+fn record_staking(label: &str, amount: u128) {
+    use subxt::ext::sp_runtime::SaturatedConversion;
+    STAKING_COUNTER
+        .with_label_values(&[label])
+        .inc_by(amount.saturated_into());
 }
 
 fn count_balance_stats(events: &Vec<EventDetails<PolkadotConfig>>) {
@@ -164,7 +198,7 @@ fn count_balance_stats(events: &Vec<EventDetails<PolkadotConfig>>) {
 
 fn record_balance(label: &str, amount: u128) {
     use subxt::ext::sp_runtime::SaturatedConversion;
-
+    log::info!("Recording balance label {label:?} with amount {amount:?}");
     BALANCE_COUNTER
         .with_label_values(&[label])
         .inc_by(amount.saturated_into());

--- a/canaries/src/main.rs
+++ b/canaries/src/main.rs
@@ -1,11 +1,10 @@
 //! Canary prototype
+mod metrics;
 use std::net::SocketAddr;
 
-use axum::routing::get;
-use axum::Router;
 use clap::Parser;
 use env_logger::Env;
-use event_forwarder::block_processing::{fetch_all_events, fetch_events, filter_events};
+use event_forwarder::block_processing::{fetch_all_events, filter_events};
 use event_forwarder::chain_listener::{
     Block,
     BlockProcessor,
@@ -13,86 +12,15 @@ use event_forwarder::chain_listener::{
     FinalizedBlockStream,
     API,
 };
-use lazy_static::lazy_static;
 use log::{error, info};
-use prometheus::{
-    register_gauge_vec,
-    register_int_counter_vec,
-    Encoder,
-    GaugeVec,
-    IntCounterVec,
-    TextEncoder,
-};
 use snafu::{ResultExt, Snafu};
+use subxt::events::EventDetails;
 use subxt::{OnlineClient, PolkadotConfig};
 use sxt_core::sxt_chain_runtime;
-use sxt_core::sxt_chain_runtime::api::attestations::events::BlockAttested;
-use sxt_core::sxt_chain_runtime::api::indexing::events::{DataSubmitted, QuorumReached};
-use sxt_core::sxt_chain_runtime::api::rewards::events::{EraPaid, Payout, PayoutError, SetupError};
 use sxt_core::sxt_chain_runtime::api::session::events::NewSession;
-use tokio::net::TcpListener;
 use url::Url;
 
-lazy_static! {
-    /// Prometheus event counter
-    pub static ref EVENT_COUNTER: IntCounterVec = register_int_counter_vec!(
-        "canary_event_total",
-        "Total count of specific events observed in finalized blocks",
-        &["type"]
-    )
-    .unwrap();
-
-    /// Annualized Reward rate tracker
-    pub static ref REWARD_RATE: GaugeVec = register_gauge_vec!(
-        "canary_era_reward_rate",
-        "Annualized staking reward rate per era",
-        &["era"]
-    ).unwrap();
-
-
-    /// Total staked tracker
-    pub static ref TOTAL_STAKED: GaugeVec = register_gauge_vec!(
-        "canary_era_total_staked",
-        "Total stake observed for a given era",
-        &["era"]
-    ).unwrap();
-
-    /// Validator reward tracker
-    pub static ref VALIDATOR_REWARD: GaugeVec = register_gauge_vec!(
-        "canary_era_validator_reward",
-        "Total validator rewards distributed in an era",
-        &["era"]
-    ).unwrap();
-
-    /// Annaulizer tracker, used for debugging
-    pub static ref ANNUALIZER: GaugeVec = register_gauge_vec!(
-        "canary_era_annualizer_multiplier",
-        "Annualizer multiplier used in APR calculation",
-        &["era"]
-    ).unwrap();
-
-}
-
-/// Serve prometheus metrics
-pub async fn serve_metrics(bind_addr: SocketAddr) -> anyhow::Result<()> {
-    let app = Router::new().route("/metrics", get(metrics_handler));
-
-    let listener = TcpListener::bind(bind_addr).await?;
-    log::info!(
-        "📊 Prometheus metrics server running on http://{}",
-        bind_addr
-    );
-
-    axum::serve(listener, app).await?;
-    Ok(())
-}
-async fn metrics_handler() -> String {
-    let metric_families = prometheus::gather();
-    let mut buffer = Vec::new();
-    let encoder = TextEncoder::new();
-    encoder.encode(&metric_families, &mut buffer).unwrap();
-    String::from_utf8(buffer).unwrap()
-}
+use crate::metrics::*;
 
 /// Canary: Substrate Finalized Block Event Monitor
 #[derive(Debug, Parser)]
@@ -162,16 +90,7 @@ use std::collections::HashMap;
 #[async_trait::async_trait]
 impl BlockProcessor for DummyProcessor {
     async fn process_block(&mut self, _api: &API, block: Block) {
-        let block_number = block.number();
         let events = fetch_all_events(&block).await.unwrap_or_default();
-
-        let attested = filter_events::<BlockAttested>(&events);
-        let submitted = filter_events::<DataSubmitted>(&events);
-        let quorum = filter_events::<QuorumReached>(&events);
-
-        let attested_count = attested.len();
-        let submitted_count = submitted.len();
-        let quorum_count = quorum.len();
 
         // Count all the events in the block by their pallet and variant
         let mut event_count = HashMap::<String, u64>::new();
@@ -191,110 +110,159 @@ impl BlockProcessor for DummyProcessor {
             EVENT_COUNTER.with_label_values(&[label]).inc_by(*count);
         });
 
-        let session_events = filter_events::<NewSession>(&events);
+        count_reward_stats(&block, &events, _api, self.annualizer).await;
 
-        if let Some(event) = session_events.first() {
-            let session_index = event.session_index;
-            info!("🧭 New session detected: {}", session_index);
+        count_balance_stats(&events);
+    }
+}
 
-            let active_era_query = sxt_chain_runtime::api::storage().staking().active_era();
-            let active_era = match _api
-                .storage()
-                .at(block.hash())
-                .fetch(&active_era_query)
-                .await
-            {
-                Ok(Some(info)) => info.index,
-                Ok(None) => {
-                    info!("No active era found at block {}", block.number());
-                    return;
-                }
-                Err(e) => {
-                    error!("❌ Failed to fetch active era: {:?}", e);
-                    return;
-                }
-            };
+fn count_balance_stats(events: &Vec<EventDetails<PolkadotConfig>>) {
+    use sxt_core::sxt_chain_runtime::api::balances::events::{
+        Burned,
+        Frozen,
+        Issued,
+        Locked,
+        Minted,
+        Rescinded,
+        Reserved,
+        Thawed,
+        Transfer,
+        Unlocked,
+        Unreserved,
+    };
+    // Unfortunately Prometheus is natively using 64 bit numbers, so the best we can do  for
+    // balance handling is saturated_into and then make sure the time frame we look at on the
+    // dashboard is using the rate instead of the absolute total value
+    events.iter().for_each(|event| {
+        if event.pallet_name().contains("Balances") {
+            if let Ok(Some(e)) = event.as_event::<Issued>() {
+                record_balance("Issued", e.amount);
+            } else if let Ok(Some(e)) = event.as_event::<Burned>() {
+                record_balance("Burned", e.amount);
+            } else if let Ok(Some(e)) = event.as_event::<Unreserved>() {
+                record_balance("Unreserved", e.amount);
+            } else if let Ok(Some(e)) = event.as_event::<Frozen>() {
+                record_balance("Frozen", e.amount);
+            } else if let Ok(Some(e)) = event.as_event::<Thawed>() {
+                record_balance("Thawed", e.amount);
+            } else if let Ok(Some(e)) = event.as_event::<Locked>() {
+                record_balance("Locked", e.amount);
+            } else if let Ok(Some(e)) = event.as_event::<Minted>() {
+                record_balance("Minted", e.amount);
+            } else if let Ok(Some(e)) = event.as_event::<Reserved>() {
+                record_balance("Reserved", e.amount);
+            } else if let Ok(Some(e)) = event.as_event::<Transfer>() {
+                record_balance("Transfer", e.amount);
+            } else if let Ok(Some(e)) = event.as_event::<Unlocked>() {
+                record_balance("Unlocked", e.amount);
+            } else if let Ok(Some(e)) = event.as_event::<Rescinded>() {
+                record_balance("Rescinded", e.amount);
+            }
+        }
+    });
+}
 
-            let prev_era = active_era.saturating_sub(1);
+fn record_balance(label: &str, amount: u128) {
+    use subxt::ext::sp_runtime::SaturatedConversion;
 
-            let era_reward_query = sxt_chain_runtime::api::storage()
-                .staking()
-                .eras_validator_reward(prev_era);
-            let era_reward = match _api
-                .storage()
-                .at(block.hash())
-                .fetch(&era_reward_query)
-                .await
-            {
-                Ok(Some(val)) => val,
-                Ok(None) => {
-                    info!("No reward data found for era {}", prev_era);
-                    return;
-                }
-                Err(e) => {
-                    error!("❌ Failed to fetch validator reward: {:?}", e);
-                    return;
-                }
-            };
+    BALANCE_COUNTER
+        .with_label_values(&[label])
+        .inc_by(amount.saturated_into());
+}
 
-            let total_staked_query = sxt_chain_runtime::api::storage()
-                .staking()
-                .eras_total_stake(prev_era);
-            let total_staked = match _api
-                .storage()
-                .at(block.hash())
-                .fetch(&total_staked_query)
-                .await
-            {
-                Ok(Some(val)) => val,
-                Ok(None) => {
-                    info!("No total stake found for era {}", prev_era);
-                    return;
-                }
-                Err(e) => {
-                    error!("❌ Failed to fetch total stake: {:?}", e);
-                    return;
-                }
-            };
+async fn count_reward_stats(
+    block: &Block,
+    events: &Vec<EventDetails<PolkadotConfig>>,
+    api: &API,
+    annualizer: f64,
+) {
+    let session_events = filter_events::<NewSession>(&events);
 
-            if total_staked == 0 {
-                info!("⚠️ Total stake for era {} is zero, skipping", prev_era);
+    if let Some(event) = session_events.first() {
+        let session_index = event.session_index;
+        info!("🧭 New session detected: {}", session_index);
+
+        let active_era_query = sxt_chain_runtime::api::storage().staking().active_era();
+        let active_era = match api
+            .storage()
+            .at(block.hash())
+            .fetch(&active_era_query)
+            .await
+        {
+            Ok(Some(info)) => info.index,
+            Ok(None) => {
+                info!("No active era found at block {}", block.number());
                 return;
             }
+            Err(e) => {
+                error!("❌ Failed to fetch active era: {:?}", e);
+                return;
+            }
+        };
 
-            let reward_rate = era_reward as f64 / total_staked as f64;
-            let annualized_rate = reward_rate * self.annualizer;
+        let prev_era = active_era.saturating_sub(1);
 
-            let era_label = &prev_era.to_string();
+        let era_reward_query = sxt_chain_runtime::api::storage()
+            .staking()
+            .eras_validator_reward(prev_era);
+        let era_reward = match api
+            .storage()
+            .at(block.hash())
+            .fetch(&era_reward_query)
+            .await
+        {
+            Ok(Some(val)) => val,
+            Ok(None) => {
+                info!("No reward data found for era {}", prev_era);
+                return;
+            }
+            Err(e) => {
+                error!("❌ Failed to fetch validator reward: {:?}", e);
+                return;
+            }
+        };
 
-            REWARD_RATE
-                .with_label_values(&[era_label])
-                .set(annualized_rate * 100.0);
+        let total_staked_query = sxt_chain_runtime::api::storage()
+            .staking()
+            .eras_total_stake(prev_era);
+        let total_staked = match api
+            .storage()
+            .at(block.hash())
+            .fetch(&total_staked_query)
+            .await
+        {
+            Ok(Some(val)) => val,
+            Ok(None) => {
+                info!("No total stake found for era {}", prev_era);
+                return;
+            }
+            Err(e) => {
+                error!("❌ Failed to fetch total stake: {:?}", e);
+                return;
+            }
+        };
 
-            TOTAL_STAKED
-                .with_label_values(&[era_label])
-                .set(total_staked as f64);
-            VALIDATOR_REWARD
-                .with_label_values(&[era_label])
-                .set(era_reward as f64);
-            ANNUALIZER
-                .with_label_values(&[era_label])
-                .set(self.annualizer);
-
-            info!(
-            "🧱 Block {} | BlockAttested: {}, DataSubmitted: {}, QuorumReached: {} | Era {}: reward={}, staked={}, rate={:.6}, annualizer={}, APR={:.2}%",
-                block_number,
-                attested_count,
-                submitted_count,
-                quorum_count,
-                prev_era,
-                era_reward,
-                total_staked,
-                reward_rate,
-                self.annualizer,
-                annualized_rate * 100.0
-            );
+        if total_staked == 0 {
+            info!("⚠️ Total stake for era {} is zero, skipping", prev_era);
+            return;
         }
+
+        let reward_rate = era_reward as f64 / total_staked as f64;
+        let annualized_rate = reward_rate * annualizer;
+
+        let era_label = &prev_era.to_string();
+
+        REWARD_RATE
+            .with_label_values(&[era_label])
+            .set(annualized_rate * 100.0);
+
+        TOTAL_STAKED
+            .with_label_values(&[era_label])
+            .set(total_staked as f64);
+        VALIDATOR_REWARD
+            .with_label_values(&[era_label])
+            .set(era_reward as f64);
+        ANNUALIZER.with_label_values(&[era_label]).set(annualizer);
     }
 }
 

--- a/canaries/src/main.rs
+++ b/canaries/src/main.rs
@@ -5,7 +5,7 @@ use axum::routing::get;
 use axum::Router;
 use clap::Parser;
 use env_logger::Env;
-use event_forwarder::block_processing::fetch_events;
+use event_forwarder::block_processing::{fetch_all_events, fetch_events, filter_events};
 use event_forwarder::chain_listener::{
     Block,
     BlockProcessor,
@@ -70,6 +70,7 @@ lazy_static! {
         "Annualizer multiplier used in APR calculation",
         &["era"]
     ).unwrap();
+
 }
 
 /// Serve prometheus metrics
@@ -157,68 +158,40 @@ async fn main() -> Result<(), CanaryError> {
 struct DummyProcessor {
     annualizer: f64,
 }
-
+use std::collections::HashMap;
 #[async_trait::async_trait]
 impl BlockProcessor for DummyProcessor {
     async fn process_block(&mut self, _api: &API, block: Block) {
         let block_number = block.number();
+        let events = fetch_all_events(&block).await.unwrap_or_default();
 
-        let attested = fetch_events::<BlockAttested>(&block)
-            .await
-            .unwrap_or_default();
-
-        let submitted = fetch_events::<DataSubmitted>(&block)
-            .await
-            .unwrap_or_default();
-
-        let quorum = fetch_events::<QuorumReached>(&block)
-            .await
-            .unwrap_or_default();
-
-        let era_paid = fetch_events::<EraPaid>(&block)
-            .await
-            .unwrap_or_default()
-            .len();
-        let payout_error = fetch_events::<PayoutError>(&block)
-            .await
-            .unwrap_or_default()
-            .len();
-        let setup_error = fetch_events::<SetupError>(&block)
-            .await
-            .unwrap_or_default()
-            .len();
-        let payout = fetch_events::<Payout>(&block)
-            .await
-            .unwrap_or_default()
-            .len();
+        let attested = filter_events::<BlockAttested>(&events);
+        let submitted = filter_events::<DataSubmitted>(&events);
+        let quorum = filter_events::<QuorumReached>(&events);
 
         let attested_count = attested.len();
         let submitted_count = submitted.len();
         let quorum_count = quorum.len();
 
-        EVENT_COUNTER
-            .with_label_values(&["BlockAttested"])
-            .inc_by(attested_count as u64);
-        EVENT_COUNTER
-            .with_label_values(&["DataSubmitted"])
-            .inc_by(submitted_count as u64);
-        EVENT_COUNTER
-            .with_label_values(&["QuorumReached"])
-            .inc_by(quorum_count as u64);
-        EVENT_COUNTER
-            .with_label_values(&["EraPaid"])
-            .inc_by(era_paid as u64);
-        EVENT_COUNTER
-            .with_label_values(&["SetupError"])
-            .inc_by(setup_error as u64);
-        EVENT_COUNTER
-            .with_label_values(&["PayoutError"])
-            .inc_by(payout_error as u64);
-        EVENT_COUNTER
-            .with_label_values(&["Payout"])
-            .inc_by(payout as u64);
+        // Count all the events in the block by their pallet and variant
+        let mut event_count = HashMap::<String, u64>::new();
+        for e in events.iter() {
+            let label = format!("{:?}.{:?}", e.pallet_name(), e.variant_name());
+            match event_count.get(&label) {
+                Some(count) => {
+                    event_count.insert(label, count + 1);
+                }
+                None => {
+                    event_count.insert(label, 1);
+                }
+            }
+        }
 
-        let session_events = fetch_events::<NewSession>(&block).await.unwrap_or_default();
+        event_count.iter().for_each(|(label, count)| {
+            EVENT_COUNTER.with_label_values(&[label]).inc_by(*count);
+        });
+
+        let session_events = filter_events::<NewSession>(&events);
 
         if let Some(event) = session_events.first() {
             let session_index = event.session_index;

--- a/canaries/src/main.rs
+++ b/canaries/src/main.rs
@@ -43,10 +43,6 @@ pub struct CanaryConfig {
     /// Bind address for Prometheus metrics (e.g., 0.0.0.0:9000)
     #[arg(long, env = "CANARY_METRICS_BIND", default_value = "0.0.0.0:9000")]
     pub metrics_bind: SocketAddr,
-
-    /// Multiplier used to annualize per-era reward rates
-    #[arg(long, env = "CANARY_ANNUALIZER", default_value_t = 8760.0)]
-    pub annualizer: f64,
 }
 
 #[tokio::main]
@@ -73,9 +69,7 @@ async fn main() -> Result<(), CanaryError> {
 
     // Set up the listener
     let stream = FinalizedBlockStream;
-    let processor = DummyProcessor {
-        annualizer: config.annualizer,
-    };
+    let processor = SimpleProcessor {};
 
     let listener = ChainListener::new(processor, stream, api)
         .await
@@ -86,13 +80,11 @@ async fn main() -> Result<(), CanaryError> {
     Ok(())
 }
 
-struct DummyProcessor {
-    annualizer: f64,
-}
+struct SimpleProcessor {}
 
 #[async_trait::async_trait]
-impl BlockProcessor for DummyProcessor {
-    async fn process_block(&mut self, _api: &API, block: Block) {
+impl BlockProcessor for SimpleProcessor {
+    async fn process_block(&mut self, api: &API, block: Block) {
         let events = fetch_all_events(&block).await.unwrap_or_default();
 
         // Parse the event names and record each one
@@ -100,7 +92,7 @@ impl BlockProcessor for DummyProcessor {
             .iter()
             .for_each(|name| record_event(name));
 
-        count_reward_stats(&block, &events, _api, self.annualizer).await;
+        count_reward_stats(&block, &events, api).await;
 
         parse_staking_stats(&events)
             .iter()
@@ -112,12 +104,7 @@ impl BlockProcessor for DummyProcessor {
     }
 }
 
-async fn count_reward_stats(
-    block: &Block,
-    events: &Vec<EventDetails<PolkadotConfig>>,
-    api: &API,
-    annualizer: f64,
-) {
+async fn count_reward_stats(block: &Block, events: &Vec<EventDetails<PolkadotConfig>>, api: &API) {
     if let Some(new_session) = filter_events::<NewSession>(&events).first() {
         match read_active_era(block, api).await {
             Ok(Some(active)) => {

--- a/canaries/src/main.rs
+++ b/canaries/src/main.rs
@@ -92,8 +92,6 @@ impl BlockProcessor for SimpleProcessor {
             .iter()
             .for_each(|name| record_event(name));
 
-        count_reward_stats(&block, &events, api).await;
-
         parse_staking_stats(&events)
             .iter()
             .for_each(|(name, val)| record_staking(name, *val));
@@ -101,29 +99,28 @@ impl BlockProcessor for SimpleProcessor {
         parse_balance_stats(&events)
             .iter()
             .for_each(|(name, val)| record_balance(name, *val));
-    }
-}
 
-async fn count_reward_stats(block: &Block, events: &Vec<EventDetails<PolkadotConfig>>, api: &API) {
-    if let Some(new_session) = filter_events::<NewSession>(&events).first() {
-        match read_active_era(block, api).await {
-            Ok(Some(active)) => {
-                // We have an active era, so let's try to get rewards details
-                let prev_era = active.saturating_sub(1);
-                let label = &prev_era.to_string();
-                if let Ok(Some(rewards)) = read_era_rewards(prev_era, block, api).await {
-                    record_era_rewards(prev_era, rewards);
+        // If it's a new session, record rewards and total stake as well
+        if has_new_session(&events) {
+            match read_active_era(&block, api).await {
+                Ok(Some(active)) => {
+                    // We have an active era, so let's try to get rewards details
+                    let prev_era = active.saturating_sub(1);
+                    if let Ok(Some(rewards)) = read_era_rewards(prev_era, &block, api).await {
+                        record_era_rewards(prev_era, rewards);
+                    }
+                    if let Ok(Some(total_staked)) = read_total_staked(prev_era, &block, api).await {
+                        record_era_total_stake(prev_era, total_staked);
+                    }
                 }
-                if let Ok(Some(total_staked)) = read_total_staked(prev_era, block, api).await {
-                    record_era_total_stake(prev_era, total_staked);
+                Ok(None) => {
+                    // There was no error retriving the era from the chain, but the current era was
+                    // None
+                    log::warn!("Active Era was None for block {:?}", block.hash());
                 }
-            }
-            Ok(None) => {
-                // There was no error retriving the era from the chain, but the current era was
-                // None
-            }
-            Err(e) => {
-                log::error!("Error trying to retrieve active_era {e:?}");
+                Err(e) => {
+                    log::error!("Error trying to retrieve active_era {e:?}");
+                }
             }
         }
     }

--- a/canaries/src/main.rs
+++ b/canaries/src/main.rs
@@ -92,13 +92,9 @@ impl BlockProcessor for SimpleProcessor {
             .iter()
             .for_each(|name| record_event(name));
 
-        parse_staking_stats(&events)
-            .iter()
-            .for_each(|(name, val)| record_staking(name, *val));
+        parse_staking_stats(&events).iter().for_each(record_staking);
 
-        parse_balance_stats(&events)
-            .iter()
-            .for_each(|(name, val)| record_balance(name, *val));
+        parse_balance_stats(&events).iter().for_each(record_balance);
 
         // If it's a new session, record rewards and total stake as well
         if has_new_session(&events) {

--- a/canaries/src/metrics.rs
+++ b/canaries/src/metrics.rs
@@ -77,7 +77,21 @@ lazy_static! {
     ).unwrap();
     pub static ref STAKING_COUNTER: IntCounterVec = register_int_counter_vec!(
         "canary_staking_events",
-        "Total of amounts of Staking pallet events",
+        "Total of amounts of Balance pallet events",
         &["type"]
     ).unwrap();
+}
+
+pub(crate) fn record_staking(label: &str, amount: u128) {
+    use subxt::ext::sp_runtime::SaturatedConversion;
+    STAKING_COUNTER
+        .with_label_values(&[label])
+        .inc_by(amount.saturated_into());
+}
+
+pub(crate) fn record_balance(label: &str, amount: u128) {
+    use subxt::ext::sp_runtime::SaturatedConversion;
+    BALANCE_COUNTER
+        .with_label_values(&[label])
+        .inc_by(amount.saturated_into());
 }

--- a/canaries/src/metrics.rs
+++ b/canaries/src/metrics.rs
@@ -1,0 +1,78 @@
+use std::net::SocketAddr;
+
+use axum::routing::get;
+use axum::Router;
+use lazy_static::lazy_static;
+use prometheus::{
+    register_gauge_vec,
+    register_int_counter_vec,
+    Encoder,
+    GaugeVec,
+    IntCounterVec,
+    TextEncoder,
+};
+use tokio::net::TcpListener;
+
+/// Serve prometheus metrics
+pub async fn serve_metrics(bind_addr: SocketAddr) -> anyhow::Result<()> {
+    let app = Router::new().route("/metrics", get(metrics_handler));
+
+    let listener = TcpListener::bind(bind_addr).await?;
+    log::info!(
+        "📊 Prometheus metrics server running on http://{}",
+        bind_addr
+    );
+
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+async fn metrics_handler() -> String {
+    let metric_families = prometheus::gather();
+    let mut buffer = Vec::new();
+    let encoder = TextEncoder::new();
+    encoder.encode(&metric_families, &mut buffer).unwrap();
+    String::from_utf8(buffer).unwrap()
+}
+
+lazy_static! {
+    /// Prometheus event counter
+    pub static ref EVENT_COUNTER: IntCounterVec = register_int_counter_vec!(
+        "canary_event_total",
+        "Total count of specific events observed in finalized blocks",
+        &["type"]
+    )
+    .unwrap();
+
+    /// Annualized Reward rate tracker
+    pub static ref REWARD_RATE: GaugeVec = register_gauge_vec!(
+        "canary_era_reward_rate",
+        "Annualized staking reward rate per era",
+        &["era"]
+    ).unwrap();
+
+    /// Total staked tracker
+    pub static ref TOTAL_STAKED: GaugeVec = register_gauge_vec!(
+        "canary_era_total_staked",
+        "Total stake observed for a given era",
+        &["era"]
+    ).unwrap();
+    /// Validator reward tracker
+    pub static ref VALIDATOR_REWARD: GaugeVec = register_gauge_vec!(
+        "canary_era_validator_reward",
+        "Total validator rewards distributed in an era",
+        &["era"]
+    ).unwrap();
+
+    /// Annaulizer tracker, used for debugging
+    pub static ref ANNUALIZER: GaugeVec = register_gauge_vec!(
+        "canary_era_annualizer_multiplier",
+        "Annualizer multiplier used in APR calculation",
+        &["era"]
+    ).unwrap();
+
+    pub static ref BALANCE_COUNTER: IntCounterVec = register_int_counter_vec!(
+        "canary_balance_events",
+        "Total of amounts of Balance pallet events",
+        &["type"]
+    ).unwrap();
+}

--- a/canaries/src/metrics.rs
+++ b/canaries/src/metrics.rs
@@ -75,4 +75,9 @@ lazy_static! {
         "Total of amounts of Balance pallet events",
         &["type"]
     ).unwrap();
+    pub static ref STAKING_COUNTER: IntCounterVec = register_int_counter_vec!(
+        "canary_staking_events",
+        "Total of amounts of Staking pallet events",
+        &["type"]
+    ).unwrap();
 }

--- a/canaries/src/metrics.rs
+++ b/canaries/src/metrics.rs
@@ -43,13 +43,6 @@ lazy_static! {
     )
     .unwrap();
 
-    /// Annualized Reward rate tracker
-    pub static ref REWARD_RATE: GaugeVec = register_gauge_vec!(
-        "canary_era_reward_rate",
-        "Annualized staking reward rate per era",
-        &["era"]
-    ).unwrap();
-
     /// Total staked tracker
     pub static ref TOTAL_STAKED: GaugeVec = register_gauge_vec!(
         "canary_era_total_staked",

--- a/canaries/src/metrics.rs
+++ b/canaries/src/metrics.rs
@@ -13,6 +13,8 @@ use prometheus::{
 };
 use tokio::net::TcpListener;
 
+use crate::parsing::{BalanceEvent, StakingEvent};
+
 /// Serve prometheus metrics
 pub async fn serve_metrics(bind_addr: SocketAddr) -> anyhow::Result<()> {
     let app = Router::new().route("/metrics", get(metrics_handler));
@@ -81,19 +83,19 @@ pub(crate) fn record_event(label: &str) {
 }
 
 /// Add the provided amount to the metric for the provided label
-pub(crate) fn record_staking(label: &str, amount: u128) {
+pub(crate) fn record_staking(e: &StakingEvent) {
     use subxt::ext::sp_runtime::SaturatedConversion;
     STAKING_COUNTER
-        .with_label_values(&[label])
-        .inc_by(amount.saturated_into());
+        .with_label_values(&[e.label])
+        .inc_by(e.amount.saturated_into());
 }
 
 /// Add the provided amount to the metric for the provided label
-pub(crate) fn record_balance(label: &str, amount: u128) {
+pub(crate) fn record_balance(e: &BalanceEvent) {
     use subxt::ext::sp_runtime::SaturatedConversion;
     BALANCE_COUNTER
-        .with_label_values(&[label])
-        .inc_by(amount.saturated_into());
+        .with_label_values(&[e.label])
+        .inc_by(e.amount.saturated_into());
 }
 
 pub(crate) fn record_era_rewards(era: u32, amount: u128) {

--- a/canaries/src/metrics.rs
+++ b/canaries/src/metrics.rs
@@ -82,6 +82,12 @@ lazy_static! {
     ).unwrap();
 }
 
+/// Add a count for the given event name
+pub(crate) fn record_event(label: &str) {
+    EVENT_COUNTER.with_label_values(&[label]).inc_by(1);
+}
+
+/// Add the provided amount to the metric for the provided label
 pub(crate) fn record_staking(label: &str, amount: u128) {
     use subxt::ext::sp_runtime::SaturatedConversion;
     STAKING_COUNTER
@@ -89,6 +95,7 @@ pub(crate) fn record_staking(label: &str, amount: u128) {
         .inc_by(amount.saturated_into());
 }
 
+/// Add the provided amount to the metric for the provided label
 pub(crate) fn record_balance(label: &str, amount: u128) {
     use subxt::ext::sp_runtime::SaturatedConversion;
     BALANCE_COUNTER

--- a/canaries/src/metrics.rs
+++ b/canaries/src/metrics.rs
@@ -102,3 +102,15 @@ pub(crate) fn record_balance(label: &str, amount: u128) {
         .with_label_values(&[label])
         .inc_by(amount.saturated_into());
 }
+
+pub(crate) fn record_era_rewards(era: u32, amount: u128) {
+    VALIDATOR_REWARD
+        .with_label_values(&[era.to_string()])
+        .set(amount as f64);
+}
+
+pub(crate) fn record_era_total_stake(era: u32, amount: u128) {
+    TOTAL_STAKED
+        .with_label_values(&[era.to_string()])
+        .set(amount as f64);
+}

--- a/canaries/src/parsing.rs
+++ b/canaries/src/parsing.rs
@@ -1,0 +1,84 @@
+use subxt::events::EventDetails;
+use subxt::PolkadotConfig;
+
+/// Parses a given Vec of events, returning a tuple of variant name and amount for staking events
+pub(crate) fn parse_staking_stats(events: &Vec<EventDetails<PolkadotConfig>>) -> Vec<(&str, u128)> {
+    use sxt_core::sxt_chain_runtime::api::staking::events::{
+        Bonded,
+        Rewarded,
+        Slashed,
+        Unbonded,
+        Withdrawn,
+    };
+
+    events
+        .iter()
+        .filter_map(|event| {
+            let name = event.variant_name();
+            if event.pallet_name().contains("Staking") {
+                if let Ok(Some(e)) = event.as_event::<Bonded>() {
+                    return Some((name, e.amount));
+                } else if let Ok(Some(e)) = event.as_event::<Unbonded>() {
+                    return Some((name, e.amount));
+                } else if let Ok(Some(e)) = event.as_event::<Withdrawn>() {
+                    return Some((name, e.amount));
+                } else if let Ok(Some(e)) = event.as_event::<Rewarded>() {
+                    return Some((name, e.amount));
+                } else if let Ok(Some(e)) = event.as_event::<Slashed>() {
+                    return Some((name, e.amount));
+                }
+            }
+            None
+        })
+        .collect::<Vec<(&str, u128)>>()
+}
+
+/// Parses a given Vec of events, returning a tuple of variant name and amount for balance events
+pub(crate) fn parse_balance_stats(events: &Vec<EventDetails<PolkadotConfig>>) -> Vec<(&str, u128)> {
+    use sxt_core::sxt_chain_runtime::api::balances::events::{
+        Burned,
+        Frozen,
+        Issued,
+        Locked,
+        Minted,
+        Rescinded,
+        Reserved,
+        Thawed,
+        Transfer,
+        Unlocked,
+        Unreserved,
+    };
+
+    events
+        .iter()
+        .filter_map(|event| {
+            if event.pallet_name().contains("Balances") {
+                let name = event.variant_name();
+                if let Ok(Some(e)) = event.as_event::<Issued>() {
+                    return Some((name, e.amount));
+                } else if let Ok(Some(e)) = event.as_event::<Burned>() {
+                    return Some((name, e.amount));
+                } else if let Ok(Some(e)) = event.as_event::<Unreserved>() {
+                    return Some((name, e.amount));
+                } else if let Ok(Some(e)) = event.as_event::<Frozen>() {
+                    return Some((name, e.amount));
+                } else if let Ok(Some(e)) = event.as_event::<Thawed>() {
+                    return Some((name, e.amount));
+                } else if let Ok(Some(e)) = event.as_event::<Locked>() {
+                    return Some((name, e.amount));
+                } else if let Ok(Some(e)) = event.as_event::<Minted>() {
+                    return Some((name, e.amount));
+                } else if let Ok(Some(e)) = event.as_event::<Reserved>() {
+                    return Some((name, e.amount));
+                } else if let Ok(Some(e)) = event.as_event::<Transfer>() {
+                    return Some((name, e.amount));
+                } else if let Ok(Some(e)) = event.as_event::<Unlocked>() {
+                    return Some((name, e.amount));
+                } else if let Ok(Some(e)) = event.as_event::<Rescinded>() {
+                    return Some((name, e.amount));
+                }
+            }
+            None
+        })
+        .collect::<Vec<_>>()
+}

--- a/canaries/src/parsing.rs
+++ b/canaries/src/parsing.rs
@@ -1,3 +1,4 @@
+use event_forwarder::block_processing::filter_events;
 use subxt::events::EventDetails;
 use subxt::PolkadotConfig;
 
@@ -88,4 +89,10 @@ pub(crate) fn parse_balance_stats(events: &Vec<EventDetails<PolkadotConfig>>) ->
             None
         })
         .collect::<Vec<_>>()
+}
+
+/// Returns true if the provided event list has a NewSession event in it
+pub(crate) fn has_new_session(events: &Vec<EventDetails<PolkadotConfig>>) -> bool {
+    use sxt_core::sxt_chain_runtime::api::session::events::NewSession;
+    !filter_events::<NewSession>(events).is_empty()
 }

--- a/canaries/src/parsing.rs
+++ b/canaries/src/parsing.rs
@@ -2,7 +2,7 @@ use event_forwarder::block_processing::filter_events;
 use subxt::events::EventDetails;
 use subxt::PolkadotConfig;
 
-pub(crate) fn parse_event_names(events: &Vec<EventDetails<PolkadotConfig>>) -> Vec<String> {
+pub(crate) fn parse_event_names(events: &[EventDetails<PolkadotConfig>]) -> Vec<String> {
     events
         .iter()
         .map(|e| format!("{:?}-{:?}", e.pallet_name(), e.variant_name()))
@@ -10,7 +10,7 @@ pub(crate) fn parse_event_names(events: &Vec<EventDetails<PolkadotConfig>>) -> V
 }
 
 /// Parses a given Vec of events, returning a tuple of variant name and amount for staking events
-pub(crate) fn parse_staking_stats(events: &Vec<EventDetails<PolkadotConfig>>) -> Vec<(&str, u128)> {
+pub(crate) fn parse_staking_stats(events: &[EventDetails<PolkadotConfig>]) -> Vec<(&str, u128)> {
     use sxt_core::sxt_chain_runtime::api::staking::events::{
         Bonded,
         Rewarded,
@@ -42,7 +42,7 @@ pub(crate) fn parse_staking_stats(events: &Vec<EventDetails<PolkadotConfig>>) ->
 }
 
 /// Parses a given Vec of events, returning a tuple of variant name and amount for balance events
-pub(crate) fn parse_balance_stats(events: &Vec<EventDetails<PolkadotConfig>>) -> Vec<(&str, u128)> {
+pub(crate) fn parse_balance_stats(events: &[EventDetails<PolkadotConfig>]) -> Vec<(&str, u128)> {
     use sxt_core::sxt_chain_runtime::api::balances::events::{
         Burned,
         Frozen,
@@ -92,7 +92,7 @@ pub(crate) fn parse_balance_stats(events: &Vec<EventDetails<PolkadotConfig>>) ->
 }
 
 /// Returns true if the provided event list has a NewSession event in it
-pub(crate) fn has_new_session(events: &Vec<EventDetails<PolkadotConfig>>) -> bool {
+pub(crate) fn has_new_session(events: &[EventDetails<PolkadotConfig>]) -> bool {
     use sxt_core::sxt_chain_runtime::api::session::events::NewSession;
     !filter_events::<NewSession>(events).is_empty()
 }

--- a/canaries/src/parsing.rs
+++ b/canaries/src/parsing.rs
@@ -1,6 +1,13 @@
 use subxt::events::EventDetails;
 use subxt::PolkadotConfig;
 
+pub(crate) fn parse_event_names(events: &Vec<EventDetails<PolkadotConfig>>) -> Vec<String> {
+    events
+        .iter()
+        .map(|e| format!("{:?}-{:?}", e.pallet_name(), e.variant_name()))
+        .collect::<Vec<_>>()
+}
+
 /// Parses a given Vec of events, returning a tuple of variant name and amount for staking events
 pub(crate) fn parse_staking_stats(events: &Vec<EventDetails<PolkadotConfig>>) -> Vec<(&str, u128)> {
     use sxt_core::sxt_chain_runtime::api::staking::events::{

--- a/canaries/src/parsing.rs
+++ b/canaries/src/parsing.rs
@@ -2,6 +2,7 @@ use event_forwarder::block_processing::filter_events;
 use subxt::events::EventDetails;
 use subxt::PolkadotConfig;
 
+/// Returns a list of names for the provided events, with one name entry per provided event
 pub(crate) fn parse_event_names(events: &[EventDetails<PolkadotConfig>]) -> Vec<String> {
     events
         .iter()
@@ -9,8 +10,20 @@ pub(crate) fn parse_event_names(events: &[EventDetails<PolkadotConfig>]) -> Vec<
         .collect::<Vec<_>>()
 }
 
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+pub(crate) struct StakingEvent<'a> {
+    pub label: &'a str,
+    pub amount: u128,
+}
+
+impl<'a> From<(&'a str, u128)> for StakingEvent<'a> {
+    fn from((label, amount): (&'a str, u128)) -> Self {
+        StakingEvent { label, amount }
+    }
+}
+
 /// Parses a given Vec of events, returning a tuple of variant name and amount for staking events
-pub(crate) fn parse_staking_stats(events: &[EventDetails<PolkadotConfig>]) -> Vec<(&str, u128)> {
+pub(crate) fn parse_staking_stats(events: &[EventDetails<PolkadotConfig>]) -> Vec<StakingEvent> {
     use sxt_core::sxt_chain_runtime::api::staking::events::{
         Bonded,
         Rewarded,
@@ -25,24 +38,36 @@ pub(crate) fn parse_staking_stats(events: &[EventDetails<PolkadotConfig>]) -> Ve
             let name = event.variant_name();
             if event.pallet_name().contains("Staking") {
                 if let Ok(Some(e)) = event.as_event::<Bonded>() {
-                    return Some((name, e.amount));
+                    return Some((name, e.amount).into());
                 } else if let Ok(Some(e)) = event.as_event::<Unbonded>() {
-                    return Some((name, e.amount));
+                    return Some((name, e.amount).into());
                 } else if let Ok(Some(e)) = event.as_event::<Withdrawn>() {
-                    return Some((name, e.amount));
+                    return Some((name, e.amount).into());
                 } else if let Ok(Some(e)) = event.as_event::<Rewarded>() {
-                    return Some((name, e.amount));
+                    return Some((name, e.amount).into());
                 } else if let Ok(Some(e)) = event.as_event::<Slashed>() {
-                    return Some((name, e.amount));
+                    return Some((name, e.amount).into());
                 }
             }
             None
         })
-        .collect::<Vec<(&str, u128)>>()
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+pub(crate) struct BalanceEvent<'a> {
+    pub label: &'a str,
+    pub amount: u128,
+}
+
+impl<'a> From<(&'a str, u128)> for BalanceEvent<'a> {
+    fn from((label, amount): (&'a str, u128)) -> Self {
+        BalanceEvent { label, amount }
+    }
 }
 
 /// Parses a given Vec of events, returning a tuple of variant name and amount for balance events
-pub(crate) fn parse_balance_stats(events: &[EventDetails<PolkadotConfig>]) -> Vec<(&str, u128)> {
+pub(crate) fn parse_balance_stats(events: &[EventDetails<PolkadotConfig>]) -> Vec<BalanceEvent> {
     use sxt_core::sxt_chain_runtime::api::balances::events::{
         Burned,
         Frozen,
@@ -63,27 +88,27 @@ pub(crate) fn parse_balance_stats(events: &[EventDetails<PolkadotConfig>]) -> Ve
             if event.pallet_name().contains("Balances") {
                 let name = event.variant_name();
                 if let Ok(Some(e)) = event.as_event::<Issued>() {
-                    return Some((name, e.amount));
+                    return Some((name, e.amount).into());
                 } else if let Ok(Some(e)) = event.as_event::<Burned>() {
-                    return Some((name, e.amount));
+                    return Some((name, e.amount).into());
                 } else if let Ok(Some(e)) = event.as_event::<Unreserved>() {
-                    return Some((name, e.amount));
+                    return Some((name, e.amount).into());
                 } else if let Ok(Some(e)) = event.as_event::<Frozen>() {
-                    return Some((name, e.amount));
+                    return Some((name, e.amount).into());
                 } else if let Ok(Some(e)) = event.as_event::<Thawed>() {
-                    return Some((name, e.amount));
+                    return Some((name, e.amount).into());
                 } else if let Ok(Some(e)) = event.as_event::<Locked>() {
-                    return Some((name, e.amount));
+                    return Some((name, e.amount).into());
                 } else if let Ok(Some(e)) = event.as_event::<Minted>() {
-                    return Some((name, e.amount));
+                    return Some((name, e.amount).into());
                 } else if let Ok(Some(e)) = event.as_event::<Reserved>() {
-                    return Some((name, e.amount));
+                    return Some((name, e.amount).into());
                 } else if let Ok(Some(e)) = event.as_event::<Transfer>() {
-                    return Some((name, e.amount));
+                    return Some((name, e.amount).into());
                 } else if let Ok(Some(e)) = event.as_event::<Unlocked>() {
-                    return Some((name, e.amount));
+                    return Some((name, e.amount).into());
                 } else if let Ok(Some(e)) = event.as_event::<Rescinded>() {
-                    return Some((name, e.amount));
+                    return Some((name, e.amount).into());
                 }
             }
             None

--- a/canaries/src/storage.rs
+++ b/canaries/src/storage.rs
@@ -1,0 +1,52 @@
+use anyhow::Result;
+use event_forwarder::chain_listener::{Block, API};
+use sxt_core::sxt_chain_runtime;
+
+/// Reads the active era, if one is present. Retuns Some(u32) if an era is found, None if there is
+/// no era, and an error if we were not able to read it.
+pub(crate) async fn read_active_era(block: &Block, api: &API) -> Result<Option<u32>> {
+    let active_era_query = sxt_chain_runtime::api::storage().staking().active_era();
+
+    if let Some(active_era) = api
+        .storage()
+        .at(block.hash())
+        .fetch(&active_era_query)
+        .await?
+    {
+        Ok(Some(active_era.index))
+    } else {
+        Ok(None)
+    }
+}
+
+pub(crate) async fn read_era_rewards(era: u32, block: &Block, api: &API) -> Result<Option<u128>> {
+    let era_reward_query = sxt_chain_runtime::api::storage()
+        .staking()
+        .eras_validator_reward(era);
+    if let Some(era_reward) = api
+        .storage()
+        .at(block.hash())
+        .fetch(&era_reward_query)
+        .await?
+    {
+        Ok(Some(era_reward))
+    } else {
+        Ok(None)
+    }
+}
+
+pub(crate) async fn read_total_staked(era: u32, block: &Block, api: &API) -> Result<Option<u128>> {
+    let total_staked_query = sxt_chain_runtime::api::storage()
+        .staking()
+        .eras_total_stake(era);
+    if let Some(total_staked) = api
+        .storage()
+        .at(block.hash())
+        .fetch(&total_staked_query)
+        .await?
+    {
+        Ok(Some(total_staked))
+    } else {
+        Ok(None)
+    }
+}

--- a/event-forwarder/src/block_processing.rs
+++ b/event-forwarder/src/block_processing.rs
@@ -101,7 +101,7 @@ pub async fn fetch_all_events(
 
 /// This function takes a list of generic events and filters it to type T
 pub fn filter_events<T: subxt::events::StaticEvent + 'static>(
-    events: &Vec<subxt::events::EventDetails<PolkadotConfig>>,
+    events: &[subxt::events::EventDetails<PolkadotConfig>],
 ) -> Vec<T> {
     events
         .iter()

--- a/event-forwarder/src/block_processing.rs
+++ b/event-forwarder/src/block_processing.rs
@@ -44,10 +44,13 @@ use log::{error, info, warn};
 use snafu::{ResultExt, Snafu};
 use sp_core::crypto::AccountId32;
 use subxt::config::polkadot::PolkadotExtrinsicParamsBuilder as Params;
+use subxt::PolkadotConfig;
 use subxt_signer::sr25519::Keypair;
 use sxt_core::sxt_chain_runtime::api::attestations::events::BlockAttested;
 use sxt_core::sxt_chain_runtime::api::runtime_types::sxt_core::attestation::Attestation::EthereumAttestation;
+use sxt_core::sxt_chain_runtime::api::runtime_types::sxt_runtime::RuntimeEvent;
 use sxt_core::sxt_chain_runtime::api::staking::events::Unbonded;
+use sxt_core::sxt_chain_runtime::api::Event;
 use sxt_core::sxt_chain_runtime::{self};
 use tokio::sync::mpsc;
 use tokio::time::{sleep, Duration};
@@ -81,6 +84,29 @@ pub async fn fetch_attested_block(api: &API, attestation: &BlockAttested) -> Res
                 block_number: *block_number,
             }),
     }
+}
+
+/// Fetches all events from a block.
+pub async fn fetch_all_events(
+    block: &Block,
+) -> Result<Vec<subxt::events::EventDetails<PolkadotConfig>>, Error> {
+    Ok(block
+        .events()
+        .await
+        .context(FetchAttestationSnafu)?
+        .iter()
+        .flatten()
+        .collect::<Vec<_>>())
+}
+
+/// This function takes a list of generic events and filters it to type T
+pub fn filter_events<T: subxt::events::StaticEvent + 'static>(
+    events: &Vec<subxt::events::EventDetails<PolkadotConfig>>,
+) -> Vec<T> {
+    events
+        .iter()
+        .filter_map(|e| e.as_event::<T>().ok().flatten())
+        .collect::<Vec<_>>()
 }
 
 /// Fetches events of type `T` from a block.


### PR DESCRIPTION
# Rationale for this change
As we approach the launch of Unstaking on Mainnet, there is an increased need for visibility of the chain and its activity. This update for the Canary service provides the following improvements:

* Fetch all events only once for each block instead of once for each type of event
* Take a count of all events emitted from the chain, not just certain ones
* Added special handling for Balances events, allowing reporting of issuance, minting, burning, transfers, gas paid, and more
* Added special handling for Staking events, allowing report of bonded, unbonded, slashed, and rewarded amounts

# Are these changes tested?
Tested locally against Testnet
