### PR TITLE
feat: bump datafusion to 43, sqlparser to 0.51.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ bigdecimal = { version = "0.4.5", default-features = false }
 bincode = { version = "2.0.0", default-features = false }
 const_format = { version = "0.2.33", default-features = false }
 commitment-sql = { path = "./proof-of-sql/commitment-sql/", default-features = false }
-datafusion = { version = "38.0.0", default-features = false }
+datafusion = { version = "43", default-features = false }
 eth-ecdsa = { path = "./eth-ecdsa", default-features = false }
 sxt-runtime = { path = "./runtime", default-features = false }
 pallet-rewards = { path = "./pallets/rewards", default-features = false }
@@ -91,8 +91,8 @@ lazy_static = { version = "1.5.0", features = ["spin_no_std"] }
 on-chain-table = { path = "./proof-of-sql/on-chain-table/", default-features = false }
 postcard = { version = "1.0.10", default-features = false }
 primitive-types = { version = "0.12.2", default-features = false }
-proof-of-sql = { version = "0.121.1", default-features = false }
-proof-of-sql-planner = { version = "0.121.1", default-features = false }
+proof-of-sql = { git = "https://github.com/spaceandtimelabs/sxt-proof-of-sql.git", rev = "7f5b83187af14b661f546b853a7219feeb986013", default-features = false }
+proof-of-sql-planner = { git = "https://github.com/spaceandtimelabs/sxt-proof-of-sql.git", rev = "7f5b83187af14b661f546b853a7219feeb986013", default-features = false }
 proof-of-sql-commitment-map = { path = "./proof-of-sql/commitment-map/", default-features = false }
 commitment-column-mapping = { path = "./proof-of-sql/commitment-column-mapping/", default-features = false }
 proof-of-sql-static-setups = { path = "./proof-of-sql/static-setups/", default-features = false }
@@ -102,7 +102,7 @@ rand = { version = "0.8.5", default-features = false }
 rand_chacha = { version = "0.3.1", default-features = false }
 rayon = { version = "1.10.0" }
 snafu = { version = "0.8.4", default-features = false }
-sqlparser = { version = "0.45.0", default-features = false }
+sqlparser = { version = "0.51.0", default-features = false }
 pallet-transaction-payment = { version = "38.0.0", default-features = false }
 pallet-transaction-payment-rpc = { version = "41.0.0", default-features = false }
 tonic = { version = "0.12.3", default-features = false }
@@ -245,6 +245,6 @@ clippy.missing_docs_in_private_items = "warn"
 
 [patch.crates-io]
 # patch for sqlparser no_std compatibility with the serde feature enabled.
-# required until sqlparser releases a similar update and proof-of-sql upgrades to it.
-sqlparser = { git = "https://github.com/tlovell-sxt/datafusion-sqlparser-rs.git", rev = "a828cbea22cf19bb6b4596f902bdd6f4d14a00b8" }
+# required until sqlparser 0.56.0+ releases with the fix.
+sqlparser = { git = "https://github.com/iajoiner/datafusion-sqlparser-rs.git", rev = "ebf993d4726060b2be12e0cdcfd72b1d56ae2f41" }
 


### PR DESCRIPTION
## Summary
- Update proof-of-sql dependencies to git commit `7f5b83187af14b661f546b853a7219feeb986013` from `origin/feat/bump-arrow-53` branch
- Upgrade datafusion from 38 to 43
- Upgrade sqlparser from 0.45.0 to 0.51.0
- Updated sqlparser patch to use 0.51.0 compatible fork

Note: arrow remains at version 54 as required.

## Test plan
- [ ] Run `cargo build` to verify compilation
- [ ] Run `cargo test` to ensure all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)