### PR TITLE
fix: remove unused dependencies in sxt-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6148,15 +6148,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "exponential-backoff"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ffb309d235a642598183aeda8925e871e85dd5a433c2c877e69ff0a960f4c02"
-dependencies = [
- "fastrand 2.3.0",
-]
-
-[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21090,12 +21081,9 @@ dependencies = [
 name = "sxt-core"
 version = "0.1.0"
 dependencies = [
- "alloy",
  "arrow 54.2.1",
  "arrow-ipc-no-std",
  "bincode 2.0.0",
- "exponential-backoff",
- "glob",
  "hex",
  "k256",
  "on-chain-table",
@@ -21105,7 +21093,6 @@ dependencies = [
  "proof-of-sql",
  "proptest",
  "proptest-derive",
- "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "regex",
@@ -21117,8 +21104,6 @@ dependencies = [
  "sp-runtime-interface",
  "sqlparser",
  "subxt",
- "tokio",
- "tonic",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,6 @@ native-api = { path = "native-api", default-features = false }
 num-bigint = { version = "0.4", default-features = false }
 num_cpus = { version = "1.16.0" }
 clap = { version = "4.5.3" }
-exponential-backoff = { version = "2.0.0", default-features = false }
 curve25519-dalek = { version = "4.1.3", default-features = false }
 futures = { version = "0.3.30" }
 indexmap = { version = "2.5.0", default-features = false }
@@ -134,7 +133,6 @@ alloy-json-abi = { version = "1.5.1", default-features = false }
 alloy-signer = { version = "1.1.3", default-features = false }
 alloy-signer-local = { version = "1.1.3", default-features = false }
 
-glob = "0.3.1"
 eth_merkle_tree = { version = "=0.1.1", default-features = false }
 anyhow = { version = "1.0.95", default-features = false }
 rand_core = { version = "0.6", default-features = false }

--- a/sxt-core/Cargo.toml
+++ b/sxt-core/Cargo.toml
@@ -28,17 +28,12 @@ sqlparser = { workspace = true, default-features = false }
 serde = { workspace = true, default-features = false, features = ["derive"]}
 postcard = { workspace = true, features = ["alloc"] }
 on-chain-table = { workspace = true, default-features = false }
-tonic = { workspace = true, optional = true }
 arrow = { workspace = true, optional = true, features = ["ipc"]}
 subxt = { workspace = true, optional = true, features = ["native", "reconnecting-rpc-client"] }
-glob.workspace = true
-tokio = { workspace = true, optional = true }
 proof-of-sql = { workspace = true, default-features = false }
-exponential-backoff = { workspace = true, default-features = false, optional = true }
 k256 = { workspace = true, default-features = false }
 sha3 = { workspace = true, default-features = false }
 hex = { workspace = true, default-features = false }
-alloy = { workspace = true, optional = true, features = ["full"]}
 serde_json = { workspace = true, default-features = false, features = ["alloc"] }
 regex = { workspace = true, default-features = false }
 rand_core = { workspace = true, default-features = false }
@@ -48,7 +43,6 @@ proptest-derive = { workspace = true, optional = true }
 arrow-ipc-no-std.workspace = true
 
 [dev-dependencies]
-rand = "0.8.5"
 proptest = { workspace = true, features = ["std"] }
 arrow = { workspace = true, features = ["ipc"] }
 on-chain-table = { workspace = true, features = ["arrow", "proptest"] }
@@ -59,18 +53,14 @@ default = ["std"]
 std = [
 	"polkadot-sdk/std",
 	"sp-runtime-interface/std",
-	"dep:alloy",
 	"hex/std",
 	"k256/std",
 	"sha3/std",
 	"codec/std",
 	"on-chain-table/arrow",
 	"scale-info/std",
-	"dep:tokio",
-	"dep:tonic",
 	"dep:arrow",
-	"dep:subxt",
-	"dep:exponential-backoff",
+        "dep:subxt",
 ]
 runtime-benchmarks = []
 proptest = ["std", "dep:proptest", "on-chain-table/proptest", "dep:proptest-derive"]

--- a/sxt-core/src/lib.rs
+++ b/sxt-core/src/lib.rs
@@ -1,5 +1,9 @@
 //! TODO: add docs
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(
+    all(feature = "std", feature = "proptest"),
+    warn(unused_crate_dependencies)
+)]
 
 extern crate alloc;
 extern crate core;


### PR DESCRIPTION

# Rationale for this change
Dependency hygiene is a little lacking in this repository. sxt-core happens to still have lingering dependencies from when it was responsible for submitting data to an arrow flight server. This removes all unused dependencies from sxt-core.

# What changes are included in this PR?
- **fix: remove unused dependencies from sxt-core**
- **fix: warn unused_crate_dependencies in sxt-core**

# Are these changes tested?
These changes do not affect existing functionality, which should be verified by existing tests.
