### PR TITLE
docs: Update Bootnode List

### DIFF
--- a/docs/indexer.md
+++ b/docs/indexer.md
@@ -190,8 +190,11 @@ services:
       --keystore-path /key
       --node-key-file /node-key/subkey.key
       --bootnodes "/dns/validator0.mainnet.sxt.network/tcp/30333/p2p/12D3KooWK4MUYTiz8H6gG98JwN3bT11keivvFLYjtwEv5sqhwkAt"
-      --bootnodes "/dns/validator1.mainnet.sxt.network/tcp/30333/p2p/12D3KooWF92asK6nd1DTo4Hng3ekGpV2UYW9mSXJaXqB9RKGtyFU"
-      --bootnodes "/dns/validator2.mainnet.sxt.network/tcp/30333/p2p/12D3KooWRdhvrmMziPGeLxB7jtbe7h5q54Qth8KWjoCPaLn9Hv4v"
+      --bootnodes "/dns/validator.mainnet-sxt.ethernodes.io/tcp/30333/p2p/12D3KooWMEq9xSwmr8uTthCb6KM86av1T7AYe44kDPxWovEqzq1w"
+      --bootnodes "/dns/bootnode1.sxt.blockhunters.services/tcp/30333/p2p/12D3KooWN8ZsZDNVr1ooMWJtsqMNHCVaQ4cvxvB8kELqrZeqct79"
+      --bootnodes "/dns/bootnode2.sxt.blockhunters.services/tcp/30333/p2p/12D3KooWSvSQNVHGmK965dKcCDGaxtyeY1XPCMwFUSLC8opguG1T"
+      --bootnodes "/ip4/51.210.3.173/tcp/30333/p2p/12D3KooWRUd3BqRyiGfhxVb2BSyUDLK5nHHNXTddZpqzqvQ73C9u"
+      --bootnodes "/ip4/141.95.65.179/tcp/30683/p2p/12D3KooWQ8xPXuBww4qSumnjycjjKDThFUj4nDgGS3UPoLyRBvqJ"
       --validator
       --port 30333
       --log info

--- a/docs/mainnet.md
+++ b/docs/mainnet.md
@@ -55,12 +55,15 @@ docker run -it --rm \
 
 ### 1.3. Mainnet Bootnodes
 
-Bootnodes on SXT networks are trusted peers on the network that a new node will first connect to and find more peers to download blocks from. The three bootnodes listed below are hosted by Space and Time:
+Bootnodes on SXT networks are trusted peers on the network that a new node will first connect to and find more peers to download blocks from. The six bootnodes listed below are hosted by Space and Time and trusted partners:
 
 ```
 /dns/validator0.mainnet.sxt.network/tcp/30333/p2p/12D3KooWK4MUYTiz8H6gG98JwN3bT11keivvFLYjtwEv5sqhwkAt
-/dns/validator1.mainnet.sxt.network/tcp/30333/p2p/12D3KooWF92asK6nd1DTo4Hng3ekGpV2UYW9mSXJaXqB9RKGtyFU
-/dns/validator2.mainnet.sxt.network/tcp/30333/p2p/12D3KooWRdhvrmMziPGeLxB7jtbe7h5q54Qth8KWjoCPaLn9Hv4v
+/dns/validator.mainnet-sxt.ethernodes.io/tcp/30333/p2p/12D3KooWMEq9xSwmr8uTthCb6KM86av1T7AYe44kDPxWovEqzq1w
+/dns/bootnode1.sxt.blockhunters.services/tcp/30333/p2p/12D3KooWN8ZsZDNVr1ooMWJtsqMNHCVaQ4cvxvB8kELqrZeqct79
+/dns/bootnode2.sxt.blockhunters.services/tcp/30333/p2p/12D3KooWSvSQNVHGmK965dKcCDGaxtyeY1XPCMwFUSLC8opguG1T
+/ip4/51.210.3.173/tcp/30333/p2p/12D3KooWRUd3BqRyiGfhxVb2BSyUDLK5nHHNXTddZpqzqvQ73C9u
+/ip4/141.95.65.179/tcp/30683/p2p/12D3KooWQ8xPXuBww4qSumnjycjjKDThFUj4nDgGS3UPoLyRBvqJ
 ```
 
 ### 1.4. Node Keys
@@ -113,8 +116,11 @@ docker run -d --restart always \
   --keystore-path /key \
   --node-key-file /node-key/subkey.key \
   --bootnodes "/dns/validator0.mainnet.sxt.network/tcp/30333/p2p/12D3KooWK4MUYTiz8H6gG98JwN3bT11keivvFLYjtwEv5sqhwkAt" \
-  --bootnodes "/dns/validator1.mainnet.sxt.network/tcp/30333/p2p/12D3KooWF92asK6nd1DTo4Hng3ekGpV2UYW9mSXJaXqB9RKGtyFU" \
-  --bootnodes "/dns/validator2.mainnet.sxt.network/tcp/30333/p2p/12D3KooWRdhvrmMziPGeLxB7jtbe7h5q54Qth8KWjoCPaLn9Hv4v" \
+  --bootnodes "/dns/validator.mainnet-sxt.ethernodes.io/tcp/30333/p2p/12D3KooWMEq9xSwmr8uTthCb6KM86av1T7AYe44kDPxWovEqzq1w" \
+  --bootnodes "/dns/bootnode1.sxt.blockhunters.services/tcp/30333/p2p/12D3KooWN8ZsZDNVr1ooMWJtsqMNHCVaQ4cvxvB8kELqrZeqct79" \
+  --bootnodes "/dns/bootnode2.sxt.blockhunters.services/tcp/30333/p2p/12D3KooWSvSQNVHGmK965dKcCDGaxtyeY1XPCMwFUSLC8opguG1T" \
+  --bootnodes "/ip4/51.210.3.173/tcp/30333/p2p/12D3KooWRUd3BqRyiGfhxVb2BSyUDLK5nHHNXTddZpqzqvQ73C9u" \
+  --bootnodes "/ip4/141.95.65.179/tcp/30683/p2p/12D3KooWQ8xPXuBww4qSumnjycjjKDThFUj4nDgGS3UPoLyRBvqJ" \
   --validator \
   --port 30333 \
   --log info \
@@ -158,8 +164,11 @@ services:
       --keystore-path /key
       --node-key-file /node-key/subkey.key
       --bootnodes "/dns/validator0.mainnet.sxt.network/tcp/30333/p2p/12D3KooWK4MUYTiz8H6gG98JwN3bT11keivvFLYjtwEv5sqhwkAt"
-      --bootnodes "/dns/validator1.mainnet.sxt.network/tcp/30333/p2p/12D3KooWF92asK6nd1DTo4Hng3ekGpV2UYW9mSXJaXqB9RKGtyFU"
-      --bootnodes "/dns/validator2.mainnet.sxt.network/tcp/30333/p2p/12D3KooWRdhvrmMziPGeLxB7jtbe7h5q54Qth8KWjoCPaLn9Hv4v"
+      --bootnodes "/dns/validator.mainnet-sxt.ethernodes.io/tcp/30333/p2p/12D3KooWMEq9xSwmr8uTthCb6KM86av1T7AYe44kDPxWovEqzq1w" \
+      --bootnodes "/dns/bootnode1.sxt.blockhunters.services/tcp/30333/p2p/12D3KooWN8ZsZDNVr1ooMWJtsqMNHCVaQ4cvxvB8kELqrZeqct79" \
+      --bootnodes "/dns/bootnode2.sxt.blockhunters.services/tcp/30333/p2p/12D3KooWSvSQNVHGmK965dKcCDGaxtyeY1XPCMwFUSLC8opguG1T" \
+      --bootnodes "/ip4/51.210.3.173/tcp/30333/p2p/12D3KooWRUd3BqRyiGfhxVb2BSyUDLK5nHHNXTddZpqzqvQ73C9u" \
+      --bootnodes "/ip4/141.95.65.179/tcp/30683/p2p/12D3KooWQ8xPXuBww4qSumnjycjjKDThFUj4nDgGS3UPoLyRBvqJ" \
       --validator
       --port 30333
       --log info


### PR DESCRIPTION
Include trusted partner bootnodes in addition to SxT managed ones.

# Rationale for this change

In the interest of strengthening the decentralization of the SXT network, we want a wider variety of bootnodes that are not all hosted by SxT.

# What changes are included in this PR?

Simple documentation change to include a list of node addresses that have been tested as bootnodes.

# Are these changes tested?

Yes. Though the change is just a documentation change, each bootnode in the list was listed as the sole bootnode that a new node joining the network would use to start syncing blocks. In each case, the new node was able to successfully start syncing blocks.
