### PR TITLE
chore(runtime): bump spec_version 249 -> 250

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -208,7 +208,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 249,
+    spec_version: 250,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Required so clients (Polkadot.JS Apps, subxt, block explorers) refresh their cached metadata after the prover-db-indexer pallet was wired into construct_runtime!. Without the bump, the new pallet is invisible to tools that key metadata by spec_version even though setCode succeeds.

# Rationale for this change

<!-- 
Why are you proposing this change? Explaining clearly why changes are proposed helps reviewers
understand your changes and offer better suggestions for fixes.  

Please delete this comment as this will be part of the merge commit message -->

# What changes are included in this PR?

<!--
It is often worth providing a summary of the individual changes in this PR.

Please delete this comment as this will be part of the merge commit message -->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Please delete this comment as this will be part of the merge commit message -->
