### PR TITLE
build: bump node version to 1.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21176,7 +21176,7 @@ dependencies = [
 
 [[package]]
 name = "sxt-node"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "bs58 0.5.1",
  "clap 4.5.32",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sxt-node"
 description = "The Space and Time Transaction Node"
-version = "1.3.0"
+version = "1.4.0"
 license = "Unlicense"
 authors.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
# Rationale for this change
Recent changes to the node have added additional functionality for off-chain-workers (in the runtime) that can be configured using the node CLI.

# What changes are included in this PR?
This change bumps the node version in accordance with the new CLI feature.

# Are these changes tested?
These changes do not affect existing functionality, which should be verified by existing tests.
