### PR TITLE
build: add perl as a nix buildInput

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,7 @@
           (mkShell.override {stdenv = gcc13Stdenv;}) {
             buildInputs = [
               openssl
+              perl # secretly a dependency of openssl
               (rust-bin.fromRustupToolchainFile ./rust-toolchain.toml)
               protobuf
               pkg-config


### PR DESCRIPTION
# Rationale for this change
This was needed to compile ssl libraries inside a more barebones docker image `nixos/nix`.

# What changes are included in this PR?
Adds `perl` to the nix shell's build inputs.

# Are these changes tested?
These changes do not affect existing functionality, which should be verified by existing tests.
