### PR TITLE
refactor: address clippy allowances in prover_db_indexer

### DIFF
--- a/pallets/prover_db_indexer/src/http_client.rs
+++ b/pallets/prover_db_indexer/src/http_client.rs
@@ -33,7 +33,6 @@ const PATH_CHECKPOINT: &str = "v1/checkpoint";
 /// body as UTF-8 lossy so the operator can read whatever the server said
 /// (often a plain-text reason for 4xx/5xx).
 #[derive(Debug, Snafu)]
-#[allow(clippy::enum_variant_names)]
 pub enum Error {
     /// Failed to send the HTTP request.
     #[snafu(display("failed to send HTTP request"))]
@@ -43,7 +42,7 @@ pub enum Error {
     DeadlineReached,
     /// IO or unknown error during HTTP request.
     #[snafu(display("HTTP IO error"))]
-    IoError,
+    Io,
     /// Server returned a non-200 status code. Carries the response body
     /// so the caller can surface whatever the server said about the failure.
     #[snafu(display(
@@ -208,8 +207,8 @@ fn post(url: &str, body: &[u8]) -> Result<Vec<u8>, Error> {
                 polkadot_sdk::sp_runtime::offchain::http::Error::DeadlineReached => {
                     Error::DeadlineReached
                 }
-                polkadot_sdk::sp_runtime::offchain::http::Error::IoError => Error::IoError,
-                polkadot_sdk::sp_runtime::offchain::http::Error::Unknown => Error::IoError,
+                polkadot_sdk::sp_runtime::offchain::http::Error::IoError => Error::Io,
+                polkadot_sdk::sp_runtime::offchain::http::Error::Unknown => Error::Io,
             }
         })?;
 

--- a/pallets/prover_db_indexer/src/lib.rs
+++ b/pallets/prover_db_indexer/src/lib.rs
@@ -53,7 +53,6 @@ mod http_client;
 mod offchain_consumer;
 
 /// Generated protobuf types for the indexer HTTP adapter wire format.
-#[allow(missing_docs, clippy::missing_docs_in_private_items)]
 mod proto {
     include!(concat!(env!("OUT_DIR"), "/io.spaceandtime.indexer.rs"));
 }

--- a/pallets/prover_db_indexer/src/lib.rs
+++ b/pallets/prover_db_indexer/src/lib.rs
@@ -113,12 +113,7 @@ pub enum ConsumerError {
 }
 
 #[polkadot_sdk::frame_support::pallet]
-#[allow(
-    missing_docs,
-    clippy::missing_docs_in_private_items,
-    clippy::manual_inspect,
-    dead_code
-)]
+#[allow(clippy::manual_inspect)]
 pub mod pallet {
     use alloc::vec::Vec;
 
@@ -145,10 +140,6 @@ pub mod pallet {
 
     #[pallet::config]
     pub trait Config: polkadot_sdk::frame_system::Config {
-        /// The runtime's overarching event type.
-        type RuntimeEvent: From<Event<Self>>
-            + IsType<<Self as polkadot_sdk::frame_system::Config>::RuntimeEvent>;
-
         /// Maximum number of blocks the OCW will walk in a single
         /// invocation. Controls catch-up speed: with 6s block time and
         /// the default of 100, catch-up is ~100x realtime. Lower values
@@ -164,21 +155,6 @@ pub mod pallet {
         /// a crashed validator.
         #[pallet::constant]
         type OcwLockDeadlineMs: Get<u64>;
-    }
-
-    #[pallet::event]
-    #[pallet::generate_deposit(pub(super) fn deposit_event)]
-    pub enum Event<T: Config> {
-        /// The offchain indexer successfully forwarded a block.
-        BlockForwarded {
-            /// Block number that was successfully forwarded.
-            block_number: u64,
-        },
-        /// The offchain indexer encountered an error.
-        ForwardingError {
-            /// Block number that the forwarder failed on.
-            block_number: u64,
-        },
     }
 
     #[pallet::hooks]

--- a/pallets/prover_db_indexer/src/mock.rs
+++ b/pallets/prover_db_indexer/src/mock.rs
@@ -36,7 +36,6 @@ impl frame_system::Config for Test {
 }
 
 impl pallet_prover_db_indexer::Config for Test {
-    type RuntimeEvent = RuntimeEvent;
     // Match runtime defaults so tests exercise the production limits.
     type MaxBlocksPerInvocation = ConstU64<100>;
     type OcwLockDeadlineMs = ConstU64<120_000>;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -895,7 +895,6 @@ impl pallet_rewards::Config for Runtime {
 }
 
 impl pallet_prover_db_indexer::Config for Runtime {
-    type RuntimeEvent = RuntimeEvent;
     type MaxBlocksPerInvocation = ConstU64<100>;
     type OcwLockDeadlineMs = ConstU64<120_000>;
 }


### PR DESCRIPTION
# Rationale for this change
Most allowed lints in the `prover_db_indexer` pallet are easy to address, and should be addressed. This change addresses those lints and removes their allowances.

# What changes are included in this PR?
- **refactor: rename http_client::Error::Io in prover_db_indexer**
- **refactor: remove missing docs allowance for prover_db_indexer protobuf**
- **refactor: remove event from prover_db_indexer pallet**

# Are these changes tested?
These changes do not affect existing functionality, which should be verified by existing tests.
