### PR TITLE
feat: refund submission fee to quorum submitters

### DIFF
--- a/pallets/indexing/Cargo.toml
+++ b/pallets/indexing/Cargo.toml
@@ -21,7 +21,7 @@ scale-info = { features = [
 	"derive",
 ], workspace = true }
 
-polkadot-sdk = { workspace = true, features = ["frame-benchmarking", "frame-support", "frame-system", "pallet-session", "sp-runtime", "sp-core"]}
+polkadot-sdk = { workspace = true, features = ["frame-benchmarking", "frame-support", "frame-system", "pallet-session", "pallet-balances", "sp-runtime", "sp-core"]}
 
 pallet-commitments.workspace = true
 pallet-permissions.workspace = true

--- a/pallets/indexing/src/lib.rs
+++ b/pallets/indexing/src/lib.rs
@@ -515,7 +515,7 @@ pub mod pallet {
             &table_insert_quorum,
             &quorum_scope,
         )? {
-            finalize_quorum::<T, I>(data_quorum, data, block_number, who)?;
+            finalize_quorum::<T, I>(&data_quorum, data, block_number, who)?;
         }
 
         Ok(())
@@ -647,7 +647,7 @@ pub mod pallet {
     /// - emitting `QuorumReached` event
     /// - cleaning up submissions
     fn finalize_quorum<T, I>(
-        quorum: DataQuorum<T::AccountId, T::Hash>,
+        quorum: &DataQuorum<T::AccountId, T::Hash>,
         row_data: RowData,
         block_number: Option<u64>,
         submitter: T::AccountId,
@@ -656,7 +656,7 @@ pub mod pallet {
         T: Config<I>,
         I: NativeApi,
     {
-        clean_up_and_record_quorum::<T, I>(&quorum);
+        clean_up_and_record_quorum::<T, I>(quorum);
 
         // Deserialize into Arrow-compatible OnChainTable
         let table_bytes = I::record_batch_to_onchain(sxt_core::native::RowData { row_data })

--- a/pallets/indexing/src/lib.rs
+++ b/pallets/indexing/src/lib.rs
@@ -20,6 +20,7 @@ pub mod weights;
 // Do not remove this or the same attribute for the pallet
 // The cargo doc command will fail because of a bug even though the code is working properly
 pub use pallet::*;
+use sxt_core::fees::{TARGET_BYTE_FEE, WEIGHT_FEE};
 pub use sxt_core::indexing::*;
 pub use weights::*;
 
@@ -40,11 +41,13 @@ pub mod pallet {
     use pallet_tables::pallet::BlockEnforcementMode;
     use pallet_tables::BlockEnforcement;
     use polkadot_sdk::frame_support::pallet_prelude::*;
+    use polkadot_sdk::frame_support::traits::fungible::Mutate;
+    use polkadot_sdk::frame_support::traits::tokens::Preservation;
     use polkadot_sdk::frame_support::Blake2_128Concat;
     use polkadot_sdk::frame_system;
     use polkadot_sdk::frame_system::pallet_prelude::*;
     use polkadot_sdk::sp_runtime::traits::Hash;
-    use polkadot_sdk::sp_runtime::BoundedVec;
+    use polkadot_sdk::sp_runtime::{BoundedVec, SaturatedConversion};
     use proof_of_sql_commitment_map::CommitmentScheme;
     use sxt_core::permissions::{IndexingPalletPermission, PermissionLevel};
     use sxt_core::prover_db_indexer::EventCapture;
@@ -68,6 +71,7 @@ pub mod pallet {
         + pallet_commitments::Config
         + pallet_tables::Config
         + pallet_system_tables::Config
+        + polkadot_sdk::pallet_balances::Config
     {
         /// Binding for the runtime event, typically provided by an implementation
         /// in runtime/lib.rs
@@ -169,6 +173,24 @@ pub mod pallet {
             agreements: BoundedBTreeSet<T::AccountId, ConstU32<MAX_SUBMITTERS>>,
             /// Voters against this quorum
             dissents: BoundedBTreeSet<T::AccountId, ConstU32<MAX_SUBMITTERS>>,
+        },
+
+        /// The submission fee for a finalized quorum has been refunded to its submitters.
+        RefundProcessed {
+            /// The table identifier
+            table: TableIdentifier,
+            /// The batch that was refunded
+            batch_id: BatchId,
+            /// The amount refunded to each submitter
+            refund: T::Balance,
+        },
+
+        /// Emitted when a refund transfer to a submitter fails.
+        RefundError {
+            /// The submitter who was to receive the refund
+            recipient: T::AccountId,
+            /// The error received while processing the transfer
+            error: DispatchError,
         },
     }
 
@@ -515,10 +537,79 @@ pub mod pallet {
             &table_insert_quorum,
             &quorum_scope,
         )? {
+            let cost = submission_extrinsic_fee::<T, I>(
+                &data_quorum.table,
+                &data_quorum.batch_id,
+                &data,
+                block_number,
+            );
             finalize_quorum::<T, I>(&data_quorum, data, block_number, who)?;
+            refund_quorum::<T, I>(data_quorum, cost);
         }
 
         Ok(())
+    }
+
+    /// Estimates the fee paid to submit the data for a quorum, combining weight-based and
+    /// byte-length-based fee components, so it can be refunded to the quorum's submitters.
+    fn submission_extrinsic_fee<T, I>(
+        table: &TableIdentifier,
+        batch_id: &BatchId,
+        data: &RowData,
+        block_number: Option<u64>,
+    ) -> T::Balance
+    where
+        T: Config<I>,
+        I: NativeApi,
+    {
+        let base_weight = <T as frame_system::Config>::BlockWeights::get()
+            .get(DispatchClass::Normal)
+            .base_extrinsic;
+        let call_weight = submit_data_weight::<T, I>(table, data);
+        let byte_len = match block_number {
+            Some(block_number) => (table, batch_id, data, block_number).encoded_size(),
+            None => (table, batch_id, data).encoded_size(),
+        };
+
+        u128::from(base_weight.saturating_add(call_weight).ref_time())
+            .saturating_mul(WEIGHT_FEE)
+            .saturating_add(
+                byte_len
+                    .saturated_into::<u128>()
+                    .saturating_mul(TARGET_BYTE_FEE),
+            )
+            .saturated_into::<T::Balance>()
+    }
+
+    /// Refunds the submission fee to each submitter of a finalized quorum, drawing from the
+    /// table's treasury account, and emits `RefundProcessed`/`RefundError` events accordingly.
+    fn refund_quorum<T, I>(quorum: DataQuorum<T::AccountId, T::Hash>, refund: T::Balance)
+    where
+        T: Config<I>,
+        I: NativeApi,
+    {
+        let Some(treasury) = sxt_core::utils::account_id_from_table_id::<T>(&quorum.table) else {
+            // This only occurs if `AccountId32` can not be converted to the runtime's `AccountId` type,
+            // which should never happen unless the `AccountId` type changes.
+            return;
+        };
+
+        for recipient in quorum.agreements {
+            if let Err(error) = polkadot_sdk::pallet_balances::Pallet::<T>::transfer(
+                &treasury,
+                &recipient,
+                refund,
+                Preservation::Expendable,
+            ) {
+                Pallet::<T, I>::deposit_event(Event::RefundError { recipient, error });
+            }
+        }
+
+        Pallet::<T, I>::deposit_event(Event::RefundProcessed {
+            table: quorum.table,
+            batch_id: quorum.batch_id,
+            refund,
+        });
     }
 
     /// Submit data and check if we have a quorum.

--- a/pallets/indexing/src/tests.rs
+++ b/pallets/indexing/src/tests.rs
@@ -14,6 +14,7 @@ use pallet_tables::{CommitmentCreationCmd, UpdateTable};
 use polkadot_sdk::frame_support::__private::RuntimeDebug;
 use polkadot_sdk::frame_support::dispatch::DispatchResult;
 use polkadot_sdk::frame_support::pallet_prelude::TypeInfo;
+use polkadot_sdk::frame_support::traits::fungible::Mutate;
 use polkadot_sdk::frame_support::{assert_err, assert_ok};
 use polkadot_sdk::frame_system::ensure_signed;
 use polkadot_sdk::sp_core::Hasher;
@@ -32,6 +33,7 @@ use sxt_core::tables::{
     TableNamespace,
     TableType,
 };
+use sxt_core::utils::account_id_from_table_id;
 
 use crate::mock::*;
 use crate::{build_inner_batch_id, BatchId, Event, RowData};
@@ -2531,5 +2533,361 @@ fn submit_empty_blocks_respects_quorum() {
             Indexing::submit_empty_blocks(signer3, table_id.clone(), batch_id.clone(), 10, 20,),
             crate::Error::<Test, Api>::LateBatch,
         );
+    });
+}
+
+#[test]
+fn refund_is_paid_to_submitter_when_quorum_is_reached_and_treasury_is_funded() {
+    new_test_ext().execute_with(|| {
+        System::set_block_number(1);
+        let (table_id, create_statement) = sample_table_definition();
+        Tables::create_tables(
+            RuntimeOrigin::root(),
+            vec![UpdateTable {
+                ident: table_id.clone(),
+                create_statement,
+                table_type: TableType::Testing(InsertQuorumSize {
+                    public: Some(0),
+                    privileged: None,
+                }),
+                commitment: CommitmentCreationCmd::Empty(CommitmentSchemeFlags {
+                    hyper_kzg: true,
+                    dynamic_dory: true,
+                }),
+                source: sxt_core::tables::Source::Ethereum,
+            }]
+            .try_into()
+            .unwrap(),
+        )
+        .unwrap();
+
+        let treasury = account_id_from_table_id::<Test>(&table_id).unwrap();
+        assert_ok!(polkadot_sdk::pallet_balances::Pallet::<Test>::mint_into(
+            &treasury,
+            1_000_000_000_000_000_000,
+        ));
+
+        let signer_key = sp_runtime::AccountId32::new([1; 32]);
+        let signer = RuntimeOrigin::signed(signer_key.clone());
+        let who = ensure_signed(signer.clone()).unwrap();
+        pallet_permissions::Permissions::<Test>::insert(
+            who,
+            PermissionList::try_from(vec![PermissionLevel::IndexingPallet(
+                IndexingPalletPermission::SubmitDataForPublicQuorum,
+            )])
+            .unwrap(),
+        );
+
+        let test_batch = BatchId::try_from(b"test_batch".to_vec()).unwrap();
+        let internal_batch_id = build_inner_batch_id::<Test, Api>(&test_batch, &table_id);
+
+        assert_eq!(
+            polkadot_sdk::pallet_balances::Pallet::<Test>::free_balance(&signer_key),
+            0
+        );
+        let treasury_balance_before =
+            polkadot_sdk::pallet_balances::Pallet::<Test>::free_balance(&treasury);
+
+        assert_ok!(Indexing::submit_data(
+            signer,
+            table_id.clone(),
+            test_batch.clone(),
+            row_data(),
+        ));
+
+        // Quorum should be reached immediately given `public: Some(0)`
+        assert!(Indexing::final_data(&internal_batch_id).is_some());
+
+        let refunded_balance =
+            polkadot_sdk::pallet_balances::Pallet::<Test>::free_balance(&signer_key);
+        assert!(refunded_balance > 0, "submitter should have been refunded");
+
+        let treasury_balance_after =
+            polkadot_sdk::pallet_balances::Pallet::<Test>::free_balance(&treasury);
+        assert_eq!(
+            treasury_balance_before - treasury_balance_after,
+            refunded_balance
+        );
+
+        let events = System::read_events_for_pallet::<Event<Test, Api>>();
+        let refund_event = events
+            .into_iter()
+            .find(|e| matches!(e, Event::RefundProcessed { .. }))
+            .expect("expected a RefundProcessed event");
+        match refund_event {
+            Event::RefundProcessed {
+                table,
+                batch_id,
+                refund,
+            } => {
+                assert_eq!(table, table_id);
+                assert_eq!(batch_id, internal_batch_id);
+                assert_eq!(refund, refunded_balance);
+            }
+            _ => unreachable!(),
+        }
+    });
+}
+
+#[test]
+fn refund_is_paid_to_each_submitter_when_quorum_is_reached_with_two_agreements() {
+    new_test_ext().execute_with(|| {
+        System::set_block_number(1);
+        let (table_id, create_statement) = sample_table_definition();
+        Tables::create_tables(
+            RuntimeOrigin::root(),
+            vec![UpdateTable {
+                ident: table_id.clone(),
+                create_statement,
+                table_type: TableType::Testing(InsertQuorumSize {
+                    public: Some(1),
+                    privileged: None,
+                }),
+                commitment: CommitmentCreationCmd::Empty(CommitmentSchemeFlags {
+                    hyper_kzg: true,
+                    dynamic_dory: true,
+                }),
+                source: sxt_core::tables::Source::Ethereum,
+            }]
+            .try_into()
+            .unwrap(),
+        )
+        .unwrap();
+
+        let treasury = account_id_from_table_id::<Test>(&table_id).unwrap();
+        assert_ok!(polkadot_sdk::pallet_balances::Pallet::<Test>::mint_into(
+            &treasury,
+            1_000_000_000_000_000_000,
+        ));
+
+        let permissions = PermissionList::try_from(vec![PermissionLevel::IndexingPallet(
+            IndexingPalletPermission::SubmitDataForPublicQuorum,
+        )])
+        .unwrap();
+        let submitter_1 = sp_runtime::AccountId32::new([1; 32]);
+        let submitter_2 = sp_runtime::AccountId32::new([2; 32]);
+        for account in [&submitter_1, &submitter_2] {
+            let who = ensure_signed(RuntimeOrigin::signed(account.clone())).unwrap();
+            pallet_permissions::Permissions::<Test>::insert(who, permissions.clone());
+        }
+
+        let test_submission = TestSubmission {
+            table: table_id.clone(),
+            batch_id: BatchId::try_from(b"test_batch".to_vec()).unwrap(),
+            data: row_data(),
+        };
+        let internal_batch_id =
+            build_inner_batch_id::<Test, Api>(&test_submission.batch_id, &table_id);
+
+        let treasury_balance_before =
+            polkadot_sdk::pallet_balances::Pallet::<Test>::free_balance(&treasury);
+
+        // First submission — quorum not yet reached (needs to exceed 1)
+        assert_ok!(submit_test_data(
+            RuntimeOrigin::signed(submitter_1.clone()),
+            test_submission.clone()
+        ));
+        assert!(Indexing::final_data(&internal_batch_id).is_none());
+
+        // Second matching submission — quorum reached
+        assert_ok!(submit_test_data(
+            RuntimeOrigin::signed(submitter_2.clone()),
+            test_submission.clone()
+        ));
+        assert!(Indexing::final_data(&internal_batch_id).is_some());
+
+        let refund_1 = polkadot_sdk::pallet_balances::Pallet::<Test>::free_balance(&submitter_1);
+        let refund_2 = polkadot_sdk::pallet_balances::Pallet::<Test>::free_balance(&submitter_2);
+
+        assert!(refund_1 > 0, "first submitter should have been refunded");
+        assert_eq!(
+            refund_1, refund_2,
+            "both submitters should receive the same refund"
+        );
+
+        let treasury_balance_after =
+            polkadot_sdk::pallet_balances::Pallet::<Test>::free_balance(&treasury);
+        assert_eq!(
+            treasury_balance_before - treasury_balance_after,
+            refund_1 + refund_2
+        );
+
+        let refund_events: Vec<_> = System::read_events_for_pallet::<Event<Test, Api>>()
+            .into_iter()
+            .filter(|e| matches!(e, Event::RefundProcessed { .. }))
+            .collect();
+        // A single `RefundProcessed` event is emitted per finalized quorum, covering
+        // every submitter that agreed on the winning data.
+        assert_eq!(refund_events.len(), 1);
+        match &refund_events[0] {
+            Event::RefundProcessed {
+                table,
+                batch_id,
+                refund,
+            } => {
+                assert_eq!(table, &table_id);
+                assert_eq!(batch_id, &internal_batch_id);
+                assert_eq!(*refund, refund_1);
+            }
+            _ => unreachable!(),
+        }
+
+        let error_events: Vec<_> = System::read_events_for_pallet::<Event<Test, Api>>()
+            .into_iter()
+            .filter(|e| matches!(e, Event::RefundError { .. }))
+            .collect();
+        assert!(error_events.is_empty());
+    });
+}
+
+#[test]
+fn refund_is_paid_when_quorum_is_reached_via_submit_blockchain_data_with_block_number() {
+    new_test_ext().execute_with(|| {
+        System::set_block_number(1);
+        let (table_id, create_statement) = sample_table_definition();
+        Tables::create_tables(
+            RuntimeOrigin::root(),
+            vec![UpdateTable {
+                ident: table_id.clone(),
+                create_statement,
+                table_type: TableType::Testing(InsertQuorumSize {
+                    public: Some(0),
+                    privileged: None,
+                }),
+                commitment: CommitmentCreationCmd::Empty(CommitmentSchemeFlags {
+                    hyper_kzg: true,
+                    dynamic_dory: true,
+                }),
+                source: sxt_core::tables::Source::Ethereum,
+            }]
+            .try_into()
+            .unwrap(),
+        )
+        .unwrap();
+
+        let treasury = account_id_from_table_id::<Test>(&table_id).unwrap();
+        assert_ok!(polkadot_sdk::pallet_balances::Pallet::<Test>::mint_into(
+            &treasury,
+            1_000_000_000_000_000_000,
+        ));
+
+        let signer_key = sp_runtime::AccountId32::new([1; 32]);
+        let signer = RuntimeOrigin::signed(signer_key.clone());
+        let who = ensure_signed(signer.clone()).unwrap();
+        pallet_permissions::Permissions::<Test>::insert(
+            who,
+            PermissionList::try_from(vec![PermissionLevel::IndexingPallet(
+                IndexingPalletPermission::SubmitDataForPublicQuorum,
+            )])
+            .unwrap(),
+        );
+
+        let test_batch = BatchId::try_from(b"blockchain_batch".to_vec()).unwrap();
+        let internal_batch_id = build_inner_batch_id::<Test, Api>(&test_batch, &table_id);
+
+        assert_eq!(
+            polkadot_sdk::pallet_balances::Pallet::<Test>::free_balance(&signer_key),
+            0
+        );
+
+        // Exercises the `Some(block_number)` branch of `submission_extrinsic_fee`, which
+        // hashes `(table, batch_id, data, block_number)` rather than `(table, batch_id, data)`.
+        assert_ok!(Indexing::submit_blockchain_data(
+            signer,
+            table_id.clone(),
+            test_batch.clone(),
+            row_data(),
+            12345,
+        ));
+
+        assert!(Indexing::final_data(&internal_batch_id).is_some());
+
+        let refunded_balance =
+            polkadot_sdk::pallet_balances::Pallet::<Test>::free_balance(&signer_key);
+        assert!(refunded_balance > 0, "submitter should have been refunded");
+
+        let events = System::read_events_for_pallet::<Event<Test, Api>>();
+        let refund_event = events
+            .into_iter()
+            .find(|e| matches!(e, Event::RefundProcessed { .. }))
+            .expect("expected a RefundProcessed event");
+        match refund_event {
+            Event::RefundProcessed {
+                table,
+                batch_id,
+                refund,
+            } => {
+                assert_eq!(table, table_id);
+                assert_eq!(batch_id, internal_batch_id);
+                assert_eq!(refund, refunded_balance);
+            }
+            _ => unreachable!(),
+        }
+    });
+}
+
+#[test]
+fn refund_error_is_emitted_when_treasury_has_insufficient_funds() {
+    new_test_ext().execute_with(|| {
+        System::set_block_number(1);
+        let (table_id, create_statement) = sample_table_definition();
+        Tables::create_tables(
+            RuntimeOrigin::root(),
+            vec![UpdateTable {
+                ident: table_id.clone(),
+                create_statement,
+                table_type: TableType::Testing(InsertQuorumSize {
+                    public: Some(0),
+                    privileged: None,
+                }),
+                commitment: CommitmentCreationCmd::Empty(CommitmentSchemeFlags {
+                    hyper_kzg: true,
+                    dynamic_dory: true,
+                }),
+                source: sxt_core::tables::Source::Ethereum,
+            }]
+            .try_into()
+            .unwrap(),
+        )
+        .unwrap();
+
+        // Note: the treasury account is intentionally left unfunded here.
+        let signer_key = sp_runtime::AccountId32::new([1; 32]);
+        let signer = RuntimeOrigin::signed(signer_key.clone());
+        let who = ensure_signed(signer.clone()).unwrap();
+        pallet_permissions::Permissions::<Test>::insert(
+            who,
+            PermissionList::try_from(vec![PermissionLevel::IndexingPallet(
+                IndexingPalletPermission::SubmitDataForPublicQuorum,
+            )])
+            .unwrap(),
+        );
+
+        let test_batch = BatchId::try_from(b"test_batch".to_vec()).unwrap();
+
+        // The quorum should still finalize successfully even though the refund transfer fails.
+        assert_ok!(Indexing::submit_data(
+            signer,
+            table_id.clone(),
+            test_batch.clone(),
+            row_data(),
+        ));
+
+        assert_eq!(
+            polkadot_sdk::pallet_balances::Pallet::<Test>::free_balance(&signer_key),
+            0
+        );
+
+        let events = System::read_events_for_pallet::<Event<Test, Api>>();
+        let error_event = events
+            .into_iter()
+            .find(|e| matches!(e, Event::RefundError { .. }))
+            .expect("expected a RefundError event");
+        match error_event {
+            Event::RefundError { recipient, .. } => {
+                assert_eq!(recipient, signer_key);
+            }
+            _ => unreachable!(),
+        }
     });
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -400,28 +400,9 @@ impl pallet_utility::Config for Runtime {
     type WeightInfo = pallet_utility::weights::SubstrateWeight<Runtime>;
 }
 
-/// We want to base our pricing on the cost of the data insertion transaction since this is the
-/// most common action on the network. The values below are intended to represent an 'Average'
-/// Insert of 256 bytes of data per row.
-pub const AVERAGE_INSERT_SIZE_BYTES_PER_ROW: u128 = 256;
-pub const AVERAGE_INSERT_TARGET_COST_PER_ROW: u128 = MILLICENTS.saturating_mul(20);
-pub const TARGET_BYTE_FEE: u128 =
-    AVERAGE_INSERT_TARGET_COST_PER_ROW.saturating_div(AVERAGE_INSERT_SIZE_BYTES_PER_ROW);
-
-/// This value should be the coefficient of a 1-element-insert, as measured in pallet-indexing's weights.rs
-pub const INSERT_CALL_WEIGHT_PER_ELEMENT: u128 = 33_837_719;
-/// The number of elements per row that the target cost should apply to
-pub const INSERT_FEE_TARGET_ROW_LENGTH: u128 = 16;
-
-/// Insert weight for an insert with INSERT_FEE_TARGET_ROW_COUNT rows.
-pub const INSERT_FEE_TARGET_CALL_WEIGHT: u128 =
-    INSERT_CALL_WEIGHT_PER_ELEMENT.saturating_mul(INSERT_FEE_TARGET_ROW_LENGTH);
-pub const WEIGHT_FEE: u128 =
-    AVERAGE_INSERT_TARGET_COST_PER_ROW.saturating_div(INSERT_FEE_TARGET_CALL_WEIGHT);
-
 parameter_types! {
-    pub const TransactionByteFee: Balance = TARGET_BYTE_FEE;
-    pub const WeightFeePerRefTime: Balance = WEIGHT_FEE;
+    pub const TransactionByteFee: Balance = sxt_core::fees::TARGET_BYTE_FEE;
+    pub const WeightFeePerRefTime: Balance = sxt_core::fees::WEIGHT_FEE;
     pub const OperationalFeeMultiplier: u8 = 5;
     pub const TargetBlockFullness: Perquintill = Perquintill::from_percent(80);
     pub AdjustmentVariable: Multiplier = Multiplier::saturating_from_rational(1, 100_000);

--- a/sxt-core/src/fees.rs
+++ b/sxt-core/src/fees.rs
@@ -1,0 +1,20 @@
+//! Module containing `WEIGHT_FEE` and `TARGET_BYTE_FEE`.
+
+/// We want to base our pricing on the cost of the data insertion transaction since this is the
+/// most common action on the network. The values below are intended to represent an 'Average'
+/// Insert of 256 bytes of data per row.
+const AVERAGE_INSERT_SIZE_BYTES_PER_ROW: u128 = 256;
+const AVERAGE_INSERT_TARGET_COST_PER_ROW: u128 = 10_000_000_000_000u128.saturating_mul(20);
+pub const TARGET_BYTE_FEE: u128 =
+    AVERAGE_INSERT_TARGET_COST_PER_ROW.saturating_div(AVERAGE_INSERT_SIZE_BYTES_PER_ROW);
+
+/// This value should be the coefficient of a 1-element-insert, as measured in pallet-indexing's weights.rs
+const INSERT_CALL_WEIGHT_PER_ELEMENT: u128 = 33_837_719;
+/// The number of elements per row that the target cost should apply to
+const INSERT_FEE_TARGET_ROW_LENGTH: u128 = 16;
+
+/// Insert weight for an insert with INSERT_FEE_TARGET_ROW_COUNT rows.
+const INSERT_FEE_TARGET_CALL_WEIGHT: u128 =
+    INSERT_CALL_WEIGHT_PER_ELEMENT.saturating_mul(INSERT_FEE_TARGET_ROW_LENGTH);
+pub const WEIGHT_FEE: u128 =
+    AVERAGE_INSERT_TARGET_COST_PER_ROW.saturating_div(INSERT_FEE_TARGET_CALL_WEIGHT);

--- a/sxt-core/src/lib.rs
+++ b/sxt-core/src/lib.rs
@@ -26,6 +26,9 @@ pub mod indexing;
 /// Types consumed by the native code interface
 pub mod native;
 
+/// Constants and calculations related to on-chain fees and weights
+pub mod fees;
+
 pub mod attestation;
 
 /// Shared items for the prover-db-indexer pallet, its producer call

--- a/sxt-core/src/utils.rs
+++ b/sxt-core/src/utils.rs
@@ -1,7 +1,8 @@
 use alloc::vec::Vec;
 
-use codec::Decode;
+use codec::{Decode, Encode};
 use polkadot_sdk::frame_system::Config as SystemConfig;
+use polkadot_sdk::sp_core::blake2_256;
 use polkadot_sdk::sp_core::crypto::AccountId32;
 use polkadot_sdk::sp_runtime::traits::StaticLookup;
 use polkadot_sdk::sp_runtime::DispatchError;
@@ -69,6 +70,19 @@ pub fn eth_address_to_substrate_account_id<T: frame_system::Config>(
     let raw_bytes = hex::decode(hex_str).map_err(|_| "Invalid hex address")?;
 
     try_get_account_from_20_byte_vec::<T>(raw_bytes)
+}
+
+/// Takes a table identifier and returns the deterministic `AccountId` of its treasury.
+pub fn account_id_from_table_id<T: frame_system::Config>(
+    table: &crate::tables::TableIdentifier,
+) -> Option<T::AccountId>
+where
+    T::AccountId: Decode,
+{
+    convert_account_id::<T>(AccountId32::new(
+        (b"sxt/table", &table.namespace, &table.name).using_encoded(blake2_256),
+    ))
+    .ok()
 }
 
 /// Convert the supplied AccountId32 to the runtime's AccountId type


### PR DESCRIPTION
# Rationale for this change

We want to allow for tables to have balances that can be used to pay for data submissions.

In this implementation, only agreements are refunded. Late submissions and dissents are not refunded. That change is left for later.

# What changes are included in this PR?

See commits.

# Are these changes tested?

Not yet. This is a draft so far.