### PR TITLE
refactor(prover-db-indexer): thread BlockNumberFor<T> through pallet

### DIFF
--- a/pallets/prover_db_indexer/src/lib.rs
+++ b/pallets/prover_db_indexer/src/lib.rs
@@ -82,10 +82,6 @@ pub enum ConsumerError {
         /// Underlying parse error from the `url` crate.
         error: url::ParseError,
     },
-    /// The runtime's `BlockNumber` didn't fit in `u64` (defensive — in
-    /// practice `BlockNumber` is `u32` so this is unreachable).
-    #[snafu(display("block number does not fit in u64"))]
-    BlockNumberOverflow,
     /// `create_table` HTTP call failed.
     #[snafu(display("create_table failed: {error}"))]
     CreateTable {
@@ -123,6 +119,13 @@ pub mod pallet {
     use polkadot_sdk::sp_runtime::offchain::storage::StorageValueRef;
     use polkadot_sdk::sp_runtime::offchain::storage_lock::{StorageLock, Time};
     use polkadot_sdk::sp_runtime::offchain::Duration;
+    use polkadot_sdk::sp_runtime::traits::{
+        One,
+        Saturating,
+        UniqueSaturatedFrom,
+        UniqueSaturatedInto,
+    };
+    use polkadot_sdk::sp_runtime::SaturatedConversion;
     use sxt_core::prover_db_indexer::{
         key_for_event,
         key_for_high_water,
@@ -174,23 +177,17 @@ pub mod pallet {
 
     impl<T: Config> EventCapture for Pallet<T> {
         fn capture_events(events: Vec<BlockEvent<'_>>) {
-            if events.is_empty() {
-                return;
-            }
-
             // Capture every event unconditionally. Per-node filtering is
             // applied later by the OCW consumer when forwarding to the
             // indexer; the offchain queue mirrors the full block so every
             // validator carries the same data, regardless of which subset
             // each indexer cares about.
 
-            // `block_number()` always fits in u64 in our runtime (BlockNumber
-            // is u32); `extrinsic_index()` is always `Some` while we're inside
-            // an extrinsic, which is the only path that reaches `capture_events`.
-            // The `unwrap_or(0)` fallbacks are defensive, not load-bearing.
-            let block: u64 = polkadot_sdk::frame_system::Pallet::<T>::block_number()
-                .try_into()
-                .unwrap_or(0);
+            // `extrinsic_index()` is always `Some` while we're inside an
+            // extrinsic, which is the only path that reaches
+            // `capture_events`. The `unwrap_or(0)` fallback is defensive,
+            // not load-bearing.
+            let block = polkadot_sdk::frame_system::Pallet::<T>::block_number();
             let ext_idx = polkadot_sdk::frame_system::Pallet::<T>::extrinsic_index().unwrap_or(0);
 
             // Per-extrinsic event payload.
@@ -254,9 +251,7 @@ pub mod pallet {
             );
 
             // 2. Current block number — passed in by `offchain_worker`.
-            let current_block: u64 = block_number
-                .try_into()
-                .map_err(|_| ConsumerError::BlockNumberOverflow)?;
+            let current_block = block_number;
 
             // 3. Ask the server for its last checkpoint. The server is the
             //    sole source of truth — no local cursor. This costs one HTTP
@@ -264,7 +259,7 @@ pub mod pallet {
             //    diverge from what the server has actually committed.
             //    A failure here is treated as transient: log and skip this
             //    round; the next OCW will retry.
-            let cursor: u64 = match crate::http_client::get_last_checkpoint(&url) {
+            let cursor_seq: u64 = match crate::http_client::get_last_checkpoint(&url) {
                 Ok(Some(seq)) => seq,
                 Ok(None) => 0,
                 Err(e) => {
@@ -276,27 +271,48 @@ pub mod pallet {
                     return Ok(());
                 }
             };
+            // Server sequence numbers are always block numbers our own
+            // producer wrote, so the u64 round-trips losslessly into
+            // `BlockNumberFor<T>`. `unique_saturated_from` clamps at
+            // `BlockNumberFor<T>::MAX` if the server ever returns an
+            // impossibly-large sequence — in that case the `start > current_block`
+            // check below turns the round into a no-op instead of overflowing.
+            let cursor: BlockNumberFor<T> = <BlockNumberFor<T>>::unique_saturated_from(cursor_seq);
 
             // 4. Walk blocks from cursor+1 to tip, capped.
-            let start = cursor + 1;
-            let end = core::cmp::min(current_block, start + T::MaxBlocksPerInvocation::get() - 1);
-
+            let one: BlockNumberFor<T> = One::one();
+            let start = cursor.saturating_add(one);
             if start > current_block {
                 return Ok(());
             }
+            let max_blocks: BlockNumberFor<T> =
+                <BlockNumberFor<T>>::unique_saturated_from(T::MaxBlocksPerInvocation::get());
+            let end = core::cmp::min(
+                current_block,
+                start.saturating_add(max_blocks).saturating_sub(one),
+            );
 
             polkadot_sdk::sp_tracing::debug!(
                 target: "prover_db_indexer",
                 "processing blocks {}..={} (server_checkpoint={}, tip={})",
-                start, end, cursor, current_block,
+                start.saturated_into::<u64>(),
+                end.saturated_into::<u64>(),
+                cursor_seq,
+                current_block.saturated_into::<u64>(),
             );
 
-            for block_num in start..=end {
+            let mut block_num = start;
+            loop {
                 Self::forward_block(&url, block_num, &include_filters)?;
 
                 // Checkpoint on the server (always, even for empty blocks).
-                crate::http_client::checkpoint(&url, block_num)
+                crate::http_client::checkpoint(&url, block_num.unique_saturated_into())
                     .map_err(|error| ConsumerError::Checkpoint { error })?;
+
+                if block_num >= end {
+                    break;
+                }
+                block_num = block_num.saturating_add(one);
             }
 
             Ok(())
@@ -307,7 +323,7 @@ pub mod pallet {
         /// captures (no high-water-mark key), this is a no-op.
         fn forward_block(
             url: &url::Url,
-            block_num: u64,
+            block_num: BlockNumberFor<T>,
             include_filters: &[TableIdentifierFilter],
         ) -> Result<(), ConsumerError> {
             let Some(hwm) = crate::offchain_consumer::read_high_water(block_num) else {
@@ -317,7 +333,7 @@ pub mod pallet {
             polkadot_sdk::sp_tracing::info!(
                 target: "prover_db_indexer",
                 "block {} — high-water-mark {}; probing for captured events",
-                block_num,
+                block_num.saturated_into::<u64>(),
                 hwm,
             );
 
@@ -340,11 +356,11 @@ pub mod pallet {
         /// HTTP forwarding done by this node's OCW.
         fn forward_events(
             url: &url::Url,
-            block_num: u64,
+            block_num: BlockNumberFor<T>,
             events: &[BlockEvent<'_>],
             include_filters: &[TableIdentifierFilter],
         ) -> Result<(), ConsumerError> {
-            let seq = block_num;
+            let seq: u64 = block_num.unique_saturated_into();
 
             for event in events {
                 let table = match event {

--- a/pallets/prover_db_indexer/src/offchain_consumer.rs
+++ b/pallets/prover_db_indexer/src/offchain_consumer.rs
@@ -6,13 +6,13 @@
 
 use alloc::vec::Vec;
 
-use codec::Decode;
+use codec::{Decode, Encode};
 use polkadot_sdk::sp_core::offchain::StorageKind;
 use sxt_core::prover_db_indexer::{key_for_event, key_for_high_water, BlockEvent};
 
 /// Read the per-block high-water-mark. `None` means the block had no
 /// captured events.
-pub fn read_high_water(block: u64) -> Option<u32> {
+pub fn read_high_water<B: Encode>(block: B) -> Option<u32> {
     let raw = polkadot_sdk::sp_io::offchain::local_storage_get(
         StorageKind::PERSISTENT,
         &key_for_high_water(block),
@@ -24,7 +24,7 @@ pub fn read_high_water(block: u64) -> Option<u32> {
 /// `None` means that extrinsic did not call `EventCapture::capture_events`.
 /// The returned `BlockEvent<'static>` decodes into `Cow::Owned` for every
 /// field, so the lifetime is purely a type-level annotation.
-pub fn read_events(block: u64, extrinsic_index: u32) -> Option<Vec<BlockEvent<'static>>> {
+pub fn read_events<B: Encode>(block: B, extrinsic_index: u32) -> Option<Vec<BlockEvent<'static>>> {
     let raw = polkadot_sdk::sp_io::offchain::local_storage_get(
         StorageKind::PERSISTENT,
         &key_for_event(block, extrinsic_index),
@@ -33,7 +33,7 @@ pub fn read_events(block: u64, extrinsic_index: u32) -> Option<Vec<BlockEvent<'s
 }
 
 /// Delete the per-block high-water-mark.
-pub fn clear_high_water(block: u64) {
+pub fn clear_high_water<B: Encode>(block: B) {
     polkadot_sdk::sp_io::offchain::local_storage_clear(
         StorageKind::PERSISTENT,
         &key_for_high_water(block),
@@ -41,7 +41,7 @@ pub fn clear_high_water(block: u64) {
 }
 
 /// Delete the per-extrinsic event payload.
-pub fn clear_events(block: u64, extrinsic_index: u32) {
+pub fn clear_events<B: Encode>(block: B, extrinsic_index: u32) {
     polkadot_sdk::sp_io::offchain::local_storage_clear(
         StorageKind::PERSISTENT,
         &key_for_event(block, extrinsic_index),

--- a/pallets/prover_db_indexer/src/tests.rs
+++ b/pallets/prover_db_indexer/src/tests.rs
@@ -17,8 +17,8 @@ use polkadot_sdk::sp_runtime::offchain::storage_lock::{StorageLock, Time};
 use polkadot_sdk::sp_runtime::offchain::Duration;
 use prost::Message;
 use sxt_core::prover_db_indexer::{
-    key_for_event,
-    key_for_high_water,
+    key_for_event as key_for_event_generic,
+    key_for_high_water as key_for_high_water_generic,
     BlockEvent,
     CreateEntry,
     EventCapture,
@@ -30,6 +30,18 @@ use sxt_core::tables::TableIdentifier;
 
 use crate::mock::*;
 use crate::{proto, PROVER_DB_CONFIG_KEY};
+
+// `MockBlock` uses `u64` for `BlockNumber` (see `frame_system::mocking`),
+// so tests must SCALE-encode the block coordinate as `u64` to match what
+// the pallet writes at capture time. These wrappers pin the block type
+// so bare integer literals at call sites don't default to `i32` and
+// silently mismatch the keys.
+fn key_for_event(block: u64, extrinsic_index: u32) -> Vec<u8> {
+    key_for_event_generic(block, extrinsic_index)
+}
+fn key_for_high_water(block: u64) -> Vec<u8> {
+    key_for_high_water_generic(block)
+}
 
 type StateArc =
     std::sync::Arc<parking_lot::RwLock<polkadot_sdk::sp_core::offchain::testing::OffchainState>>;

--- a/sxt-core/src/prover_db_indexer.rs
+++ b/sxt-core/src/prover_db_indexer.rs
@@ -61,14 +61,20 @@ const HIGH_WATER_KEY_PREFIX: &[u8] = b"prover_db_indexer/hwm";
 /// in the block that called `EventCapture::capture_events`. The OCW
 /// reads it to know how far to probe `key_for_event(block, 0..=hwm)`.
 /// Absence of this key means the block had zero captured events.
-pub fn key_for_high_water(block: u64) -> Vec<u8> {
+///
+/// Generic in `B` so producer and consumer can pass their native
+/// `BlockNumberFor<T>` type directly; SCALE-encoding both sides with the
+/// same block type is the invariant that keeps writes and reads aligned.
+pub fn key_for_high_water<B: Encode>(block: B) -> Vec<u8> {
     (HIGH_WATER_KEY_PREFIX, block).encode()
 }
 
 /// Compute the offchain DB key for the events emitted by a single
 /// extrinsic in a given block. The value at this key is a SCALE-encoded
 /// `Vec<BlockEvent>` (one extrinsic may emit several `BlockEvent`s).
-pub fn key_for_event(block: u64, extrinsic_index: u32) -> Vec<u8> {
+///
+/// See [`key_for_high_water`] for the generic block-type rationale.
+pub fn key_for_event<B: Encode>(block: B, extrinsic_index: u32) -> Vec<u8> {
     (EVENT_KEY_PREFIX, block, extrinsic_index).encode()
 }
 


### PR DESCRIPTION
# Rationale for this change

Review feedback on PRs #187/#192: u64 was used throughout the pallet where `BlockNumberFor<T>` is the correct type. Since the runtime's `BlockNumber` is `u32`, u64 misrepresented the block coordinate everywhere except the proto boundary. Also removed a dead `if events.is_empty() { return; }` guard in `capture_events` — no current call site invokes it with an empty payload.

# What changes are included in this PR?

- `sxt-core::prover_db_indexer::{key_for_event, key_for_high_water}` are now generic in the block type (any `Encode`), so producer and consumer both encode the block coordinate as `BlockNumberFor<T>`.
- Consumer walk in `run_consumer` uses `BlockNumberFor<T>` arithmetic (`saturating_add`, `min`) throughout; conversion to `u64` happens only at `crate::http_client::checkpoint()` and log-line formatting.
- `ConsumerError::BlockNumberOverflow` removed (no construction path left).

**Caveat**: SCALE encodes `u32` and `u64` differently, so the offchain DB key layout changes. Testnet redeploys with a wiped volume, so this is safe; any live indexer would need its offchain DB drained first.

# Are these changes tested?

Yes:
- `cargo test -p pallet-prover-db-indexer -p sxt-core --lib`: 57 pass.
- Full workspace `cargo check` clean.
- End-to-end validation: ran all 9 scenarios in the sxt-node-harness integration suite (actions, cross_namespace, drop_recreate, include_filter, many_columns, multi_table, overlapping_submit, partition_table, replay) — all pass against a binary built from this branch.