### PR TITLE
feat: add client externality to offchain worker

### DIFF
--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -13,8 +13,8 @@ commitment-sql = { workspace = true, optional = true, features = ["cpu-perf"] }
 log = "0.4.11"
 
 polkadot-sdk = { workspace = true, features = [
-	"sp-runtime-interface", "sp-runtime", "frame-support", 
-	"frame-benchmarking", "frame-system", "sp-core",
+	"sp-runtime-interface", "sp-runtime", "frame-support",
+	"frame-benchmarking", "frame-system", "sp-core", "sp-externalities",
 ]}
 
 # Required for the Native runtime_interface macro to work
@@ -40,6 +40,7 @@ arrow-ipc-no-std = { workspace = true, optional = true, features = ["std"] }
 proof-of-sql = { workspace = true }
 sqlparser.workspace = true
 rayon.workspace = true
+polkadot-sdk = { workspace = true, features = ["sp-io"] }
 
 [[bin]]
 name = "generate-backwards-compatibility-cases"
@@ -60,6 +61,7 @@ std = [
     "dep:proof-of-sql",
     "sxt-core/std",
     "dep:arrow-ipc-no-std",
+    "polkadot-sdk/sp-blockchain",
 ]
 generate_backwards_compatibility_cases = ["std", "dep:proptest", "dep:hex", "sxt-core/proptest", "proof-of-sql-commitment-map/proptest", "commitment-sql/proptest", "dep:proof-of-sql", "dep:clap"]
 runtime-benchmarks = ["sxt-core/runtime-benchmarks"]

--- a/native/src/client.rs
+++ b/native/src/client.rs
@@ -1,0 +1,148 @@
+//! Extension giving offchain workers read access to the node's client.
+
+use alloc::string::String;
+
+use polkadot_sdk::sp_core::storage::{StorageData, StorageKey};
+use polkadot_sdk::sp_core::H256;
+use polkadot_sdk::sp_externalities::ExternalitiesExt;
+pub use polkadot_sdk::sp_runtime_interface::runtime_interface;
+
+/// Thin interface onto the node's client, implemented by the node service and registered
+/// as a [`ClientExt`] so offchain workers can read from it.
+#[cfg(feature = "std")]
+pub trait ClientProvider: Send + Sync {
+    /// Last finalized state.
+    fn finalized_state(&self) -> Option<(H256, u32)>;
+    /// Given a block's `Hash` and a key, return the value under the key in that block.
+    fn storage(
+        &self,
+        hash: H256,
+        key: &StorageKey,
+    ) -> polkadot_sdk::sp_blockchain::Result<Option<StorageData>>;
+}
+
+#[cfg(feature = "std")]
+polkadot_sdk::sp_externalities::decl_extension! {
+    /// Externalities extension exposing the node's client to offchain workers.
+    pub struct ClientExt(std::sync::Arc<dyn ClientProvider>);
+}
+
+/// Native code interface onto the node's client, exposed to offchain workers
+/// via the [`ClientExt`] externalities extension.
+#[runtime_interface]
+pub trait Client {
+    /// Last finalized state.
+    ///
+    /// Wraps [`ClientProvider::finalized_state`], which is modeled off of `FullClient::info().finalized_state`.
+    /// Returns `None` if the [`ClientExt`] extension is not registered. Otherwise, returns `Some(FullClient::info().finalized_state)`.
+    fn finalized_state(&mut self) -> Option<Option<(H256, u32)>> {
+        ExternalitiesExt::extension(self).map(|ClientExt(provider)| provider.finalized_state())
+    }
+
+    /// Given a block's `Hash` and a key, return the value under the key in that block.
+    ///
+    /// Wraps [`ClientProvider::storage`], which is modeled off of `FullClient::storage`.
+    /// Returns `None` if the [`ClientExt`] extension is not registered. Otherwise, returns `Some(FullClient::storage(hash, key))`.
+    fn storage(
+        &mut self,
+        hash: H256,
+        key: alloc::vec::Vec<u8>,
+    ) -> Option<Result<Option<StorageData>, String>> {
+        ExternalitiesExt::extension(self).map(|ClientExt(provider)| {
+            provider
+                .storage(hash, &StorageKey(key))
+                .map_err(|error| error.to_string())
+        })
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use std::sync::Arc;
+
+    use polkadot_sdk::sp_io::TestExternalities;
+
+    use super::*;
+
+    struct MockClientProvider {
+        finalized_state: Option<(H256, u32)>,
+        storage_response: Result<Option<StorageData>, String>,
+    }
+
+    impl ClientProvider for MockClientProvider {
+        fn finalized_state(&self) -> Option<(H256, u32)> {
+            self.finalized_state
+        }
+
+        fn storage(
+            &self,
+            _hash: H256,
+            _key: &StorageKey,
+        ) -> polkadot_sdk::sp_blockchain::Result<Option<StorageData>> {
+            self.storage_response
+                .clone()
+                .map_err(polkadot_sdk::sp_blockchain::Error::UnknownBlock)
+        }
+    }
+
+    #[test]
+    fn finalized_state_is_none_when_extension_not_registered() {
+        let mut ext = TestExternalities::default();
+        ext.execute_with(|| {
+            assert_eq!(client::finalized_state(), None);
+        });
+    }
+
+    #[test]
+    fn storage_is_none_when_extension_not_registered() {
+        let mut ext = TestExternalities::default();
+        ext.execute_with(|| {
+            assert_eq!(client::storage(H256::zero(), vec![123]), None);
+        })
+    }
+
+    #[test]
+    fn finalized_state_forwards_provider_value() {
+        let mut ext = TestExternalities::default();
+        ext.register_extension(ClientExt(Arc::new(MockClientProvider {
+            finalized_state: Some((H256::repeat_byte(0xAB), 456)),
+            storage_response: Ok(None),
+        })));
+        ext.execute_with(|| {
+            assert_eq!(
+                client::finalized_state(),
+                Some(Some((H256::repeat_byte(0xAB), 456)))
+            );
+        });
+    }
+
+    #[test]
+    fn storage_forwards_provider_value() {
+        let mut ext = TestExternalities::default();
+        ext.register_extension(ClientExt(Arc::new(MockClientProvider {
+            finalized_state: None,
+            storage_response: Ok(Some(StorageData(vec![107, 108, 109]))),
+        })));
+        ext.execute_with(|| {
+            assert_eq!(
+                client::storage(H256::zero(), vec![123]),
+                Some(Ok(Some(StorageData(vec![107, 108, 109]))))
+            );
+        });
+    }
+
+    #[test]
+    fn storage_forwards_provider_error_as_string() {
+        let mut ext = TestExternalities::default();
+        ext.register_extension(ClientExt(Arc::new(MockClientProvider {
+            finalized_state: None,
+            storage_response: Err("test error".to_string()),
+        })));
+        ext.execute_with(|| {
+            assert_eq!(
+                client::storage(H256::zero(), vec![123]),
+                Some(Err("UnknownBlock: test error".to_string()))
+            );
+        });
+    }
+}

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -1,6 +1,11 @@
 //! Space and Time's crate for no_std code that is needed in the runtime and is made available through generated WASM bindings
 #![cfg_attr(not(feature = "std"), no_std)]
 
+extern crate alloc;
+
+/// Extension giving offchain workers read access to the node's client, and the
+/// runtime interface exposing it to the runtime.
+pub mod client;
 /// The space and time native code interface
 mod sxt;
 

--- a/node/src/client_provider.rs
+++ b/node/src/client_provider.rs
@@ -1,0 +1,24 @@
+//! Implements [`ClientProvider`] for a thin wrapper around [`FullClient`].
+
+use std::sync::Arc;
+
+use native::client::ClientProvider;
+use polkadot_sdk::sc_client_api::{HeaderBackend, StorageProvider};
+use polkadot_sdk::sp_blockchain;
+use polkadot_sdk::sp_core::storage::{StorageData, StorageKey};
+use polkadot_sdk::sp_core::H256;
+
+use crate::service::FullClient;
+
+/// A handle onto [`FullClient`] used to implement [`ClientProvider`] for it.
+pub(crate) struct FullClientHandle(pub(crate) Arc<FullClient>);
+
+impl ClientProvider for FullClientHandle {
+    fn finalized_state(&self) -> Option<(H256, u32)> {
+        self.0.info().finalized_state
+    }
+
+    fn storage(&self, hash: H256, key: &StorageKey) -> sp_blockchain::Result<Option<StorageData>> {
+        self.0.storage(hash, key)
+    }
+}

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -13,6 +13,8 @@ mod cli;
 /// Service Configuration
 mod command;
 
+mod client_provider;
+
 /// Service instantiation
 mod service;
 

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -51,6 +51,7 @@ pub type HostFunctions = (
     sp_io::SubstrateHostFunctions,
     sp_statement_store::runtime_api::HostFunctions,
     native::interface::HostFunctions,
+    native::client::client::HostFunctions,
 );
 
 #[cfg(feature = "runtime-benchmarks")]
@@ -58,6 +59,7 @@ pub type HostFunctions = (
     sp_io::SubstrateHostFunctions,
     sp_statement_store::runtime_api::HostFunctions,
     native::interface::HostFunctions,
+    native::client::client::HostFunctions,
     polkadot_sdk::frame_benchmarking::benchmarking::HostFunctions,
 );
 
@@ -631,8 +633,15 @@ pub fn new_full_base<N: NetworkBackend<Block, <Block as BlockT>::Hash>>(
                 network_provider: Arc::new(network.clone()),
                 is_validator: role.is_authority(),
                 enable_http_requests: true,
-                custom_extensions: move |_| {
-                    vec![Box::new(statement_store.clone().as_statement_store_ext()) as Box<_>]
+                custom_extensions: {
+                    let provider =
+                        Arc::new(crate::client_provider::FullClientHandle(client.clone()));
+                    move |_| {
+                        vec![
+                            Box::new(statement_store.clone().as_statement_store_ext()) as Box<_>,
+                            Box::new(native::client::ClientExt(provider.clone())) as Box<_>,
+                        ]
+                    }
                 },
             })
             .run(client.clone(), task_manager.spawn_handle())


### PR DESCRIPTION
# Rationale for this change

In order for an offchain worker to be able to access finalized information from the chain, we wish to give it direct access to the node's client.

# What changes are included in this PR?

See commits.

# Are these changes tested?

Yes