### PR TITLE
feat: add `db_events_at` helper that queries the client for `DBEvent`s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11716,9 +11716,18 @@ name = "pallet-prover-db-indexer"
 version = "0.1.0"
 dependencies = [
  "commitment-sql",
+ "native",
+ "native-api",
+ "pallet-commitments",
+ "pallet-indexing",
+ "pallet-permissions",
+ "pallet-system-tables",
+ "pallet-tables",
+ "pallet-zkpay",
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "polkadot-sdk 0.9.0",
+ "proof-of-sql-commitment-map",
  "prost 0.13.5",
  "prost-build 0.13.5",
  "scale-info",

--- a/pallets/prover_db_indexer/Cargo.toml
+++ b/pallets/prover_db_indexer/Cargo.toml
@@ -22,6 +22,9 @@ polkadot-sdk = { workspace = true, features = [
 
 sxt-core.workspace = true
 commitment-sql.workspace = true
+native.workspace = true
+pallet-indexing.workspace = true
+pallet-tables.workspace = true
 prost = { version = "0.13", default-features = false, features = ["prost-derive"] }
 snafu = { workspace = true }
 url = { workspace = true }
@@ -30,9 +33,16 @@ url = { workspace = true }
 prost-build = "0.13"
 
 [dev-dependencies]
-# Only direct test deps. `polkadot-sdk` already comes through `[dependencies]`
-# with `std` enabled in test builds, so we don't re-declare it here, and the
-# mock+tests don't reference any of pallet-tables / pallet-indexing / etc.
+polkadot-sdk = { workspace = true, features = [
+    "sp-staking", "frame-election-provider-support", "pallet-staking-reward-curve",
+    "pallet-timestamp", "pallet-balances", "pallet-staking", "pallet-session",
+]}
+native-api = { workspace = true, features = ["std"] }
+pallet-permissions.workspace = true
+pallet-commitments.workspace = true
+pallet-system-tables.workspace = true
+pallet-zkpay.workspace = true
+proof-of-sql-commitment-map.workspace = true
 parking_lot = "0.12"
 
 [features]
@@ -43,6 +53,9 @@ std = [
     "scale-info/std",
     "sxt-core/std",
     "commitment-sql/std",
+    "native/std",
+    "pallet-indexing/std",
+    "pallet-tables/std",
     "prost/std",
     "snafu/std",
     "url/std",

--- a/pallets/prover_db_indexer/src/db_events.rs
+++ b/pallets/prover_db_indexer/src/db_events.rs
@@ -1,0 +1,245 @@
+//! Read `pallet-tables` / `pallet-indexing` events straight from the node's
+//! client, via the `ClientExt` runtime interface from `native::client`.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::convert::Infallible;
+use core::marker::PhantomData;
+
+use codec::Decode;
+use pallet_tables::UpdateTableList;
+use polkadot_sdk::frame_support::pallet_prelude::ConstU32;
+use polkadot_sdk::frame_support::{storage_alias, BoundedVec};
+use polkadot_sdk::frame_system;
+use polkadot_sdk::sp_core::H256;
+use sxt_core::indexing::{DataQuorum, DATA_MAX_LEN};
+use sxt_core::tables::{Source, TableIdentifier, TableType};
+
+/// Errors that can occur when querying the node's client for captured events.
+#[derive(Debug, snafu::Snafu)]
+pub enum DBEventError {
+    /// This error occurs when the node's client is not available to query for events.
+    #[snafu(display("no client available to query System::Events"))]
+    NoClient,
+    /// This error occurs when the node's client is available, but the query for events fails.
+    #[snafu(display("failed to query System::Events: {message}"))]
+    Lookup {
+        /// The error message returned by the node's client when the query for events fails.
+        message: String,
+    },
+    /// This error occurs when the node's client is available, but the query for events returns an empty result.
+    #[snafu(display("System::Events is empty at this block"))]
+    Empty,
+    /// This error occurs when the node's client is available, but the query for events returns a result that cannot be decoded.
+    #[snafu(display("failed to decode System::Events: {error}"))]
+    Decode {
+        /// The error returned by the codec when decoding the result of the query for events fails.
+        error: codec::Error,
+    },
+}
+
+type RuntimeEvent<T> = <T as frame_system::Config>::RuntimeEvent;
+type EventRecord<T> = frame_system::EventRecord<RuntimeEvent<T>, <T as frame_system::Config>::Hash>;
+
+#[storage_alias]
+type Events<T: frame_system::Config> = StorageValue<frame_system::Pallet<T>, Vec<EventRecord<T>>>;
+
+/// A captured event from the node's client
+pub enum DBEvent<T: pallet_tables::Config + pallet_indexing::Config<I>, I: 'static = ()> {
+    /// Table definitions have been updated.
+    SchemaUpdated(Option<T::AccountId>, UpdateTableList),
+    /// A table has been successfully dropped.
+    TableDropped(Option<T::AccountId>, TableType, TableIdentifier, Source),
+    /// This event is emitted when a quorum is reached amongst submissions and the
+    /// data is finalized.
+    QuorumReached {
+        /// The quorum object representing the metadata about the decision
+        quorum: DataQuorum<T::AccountId, T::Hash>,
+        /// The finalized raw data in postcard serialized OnChainTable bytes
+        data: BoundedVec<u8, ConstU32<DATA_MAX_LEN>>,
+    },
+    /// Never constructed; carries the `pallet_indexing` instance this `DBEvent` was decoded
+    /// against, since none of the variants above otherwise name it.
+    #[doc(hidden)]
+    _Instance(PhantomData<I>, Infallible),
+}
+
+impl<T, I> TryFrom<EventRecord<T>> for DBEvent<T, I>
+where
+    T: pallet_tables::Config + pallet_indexing::Config<I>,
+    I: 'static,
+    RuntimeEvent<T>: TryInto<pallet_tables::Event<T>> + TryInto<pallet_indexing::Event<T, I>>,
+{
+    type Error = ();
+
+    fn try_from(record: EventRecord<T>) -> Result<Self, Self::Error> {
+        if let Ok(event) = record.event.clone().try_into() {
+            match event {
+                pallet_tables::Event::SchemaUpdated(owner, tables) => {
+                    Ok(DBEvent::SchemaUpdated(owner, tables))
+                }
+                pallet_tables::Event::TableDropped(owner, table_type, table, source) => {
+                    Ok(DBEvent::TableDropped(owner, table_type, table, source))
+                }
+                _ => Err(()),
+            }
+        } else if let Ok(pallet_indexing::Event::QuorumReached { quorum, data }) =
+            record.event.try_into()
+        {
+            Ok(DBEvent::QuorumReached { quorum, data })
+        } else {
+            Err(())
+        }
+    }
+}
+
+/// Queries the node's client for captured events at the given block hash.
+pub fn db_events_at<T, I: 'static>(
+    block_hash: H256,
+) -> Result<impl Iterator<Item = DBEvent<T, I>>, DBEventError>
+where
+    T: pallet_tables::Config + pallet_indexing::Config<I>,
+    EventRecord<T>: TryInto<DBEvent<T, I>>,
+{
+    let raw = native::client::client::storage(block_hash, Events::<T>::hashed_key().to_vec())
+        .ok_or(DBEventError::NoClient)?
+        .map_err(|message| DBEventError::Lookup { message })?
+        .ok_or(DBEventError::Empty)?;
+
+    Ok(Vec::<EventRecord<T>>::decode(&mut raw.0.as_slice())
+        .map_err(|error| DBEventError::Decode { error })?
+        .into_iter()
+        .filter_map(|record| record.try_into().ok()))
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use native_api::Api;
+    use pallet_tables::UpdateTableList;
+    use polkadot_sdk::frame_support::BoundedVec;
+    use polkadot_sdk::pallet_balances;
+    use polkadot_sdk::sp_core::storage::StorageData;
+    use polkadot_sdk::sp_core::H256;
+    use polkadot_sdk::sp_runtime::AccountId32;
+    use sxt_core::indexing::{BatchId, DataQuorum, SubmitterList};
+    use sxt_core::tables::{QuorumScope, Source, TableIdentifier, TableType};
+
+    use super::{db_events_at, DBEvent, DBEventError};
+    use crate::mock::{event_record, new_test_ext, MockClientProvider, Test};
+
+    #[test]
+    fn no_client_when_extension_not_registered() {
+        let mut ext = new_test_ext();
+        ext.execute_with(|| {
+            assert!(matches!(
+                db_events_at::<Test, Api>(H256::zero()),
+                Err(DBEventError::NoClient)
+            ));
+        });
+    }
+
+    #[test]
+    fn lookup_error_is_forwarded() {
+        let mut ext = new_test_ext();
+        ext.register_extension(MockClientProvider::client_ext(
+            None,
+            [Err("test error".to_string())],
+        ));
+        ext.execute_with(|| {
+            let err = db_events_at::<Test, Api>(H256::zero()).err().unwrap();
+            assert!(
+                matches!(err, DBEventError::Lookup { message } if message == "UnknownBlock: test error")
+            );
+        });
+    }
+
+    #[test]
+    fn empty_when_no_value_at_key() {
+        let mut ext = new_test_ext();
+        ext.register_extension(MockClientProvider::client_ext(None, [Ok(None)]));
+        ext.execute_with(|| {
+            assert!(matches!(
+                db_events_at::<Test, Api>(H256::zero()),
+                Err(DBEventError::Empty)
+            ));
+        });
+    }
+
+    #[test]
+    fn decode_error_on_garbage_bytes() {
+        let mut ext = new_test_ext();
+        ext.register_extension(MockClientProvider::client_ext(
+            None,
+            [Ok(Some(StorageData(alloc::vec![0xFF, 0xFF, 0xFF])))],
+        ));
+        ext.execute_with(|| {
+            assert!(matches!(
+                db_events_at::<Test, Api>(H256::zero()),
+                Err(DBEventError::Decode { .. })
+            ));
+        });
+    }
+
+    #[test]
+    fn decodes_and_filters_events() {
+        let records = vec![
+            event_record(pallet_tables::Event::<Test>::SchemaUpdated(
+                None,
+                UpdateTableList::default(),
+            )),
+            event_record(pallet_tables::Event::<Test>::TableDropped(
+                None,
+                TableType::CoreBlockchain,
+                TableIdentifier::from_str_unchecked("TABLE1", "NAMESPACE"),
+                Source::Ethereum,
+            )),
+            event_record(pallet_indexing::Event::<Test, Api>::QuorumReached {
+                quorum: DataQuorum {
+                    table: TableIdentifier::from_str_unchecked("TABLE2", "NAMESPACE"),
+                    batch_id: BatchId::default(),
+                    data_hash: H256::zero(),
+                    block_number: Default::default(),
+                    agreements: SubmitterList::default(),
+                    dissents: SubmitterList::default(),
+                    quorum_scope: QuorumScope::Public,
+                },
+                data: BoundedVec::try_from(vec![1u8, 2, 3]).unwrap(),
+            }),
+            event_record(pallet_balances::Event::<Test>::Endowed {
+                account: AccountId32::new([0u8; 32]),
+                free_balance: 0,
+            }),
+            event_record(pallet_tables::Event::<Test>::TableUuidUpdated {
+                old_uuid: Default::default(),
+                new_uuid: Default::default(),
+                version: Default::default(),
+                table: TableIdentifier::from_str_unchecked("TABLE3", "NAMESPACE"),
+            }),
+        ];
+        let mut ext = new_test_ext();
+        ext.register_extension(MockClientProvider::client_ext(
+            None,
+            [Ok(Some(StorageData(codec::Encode::encode(&records))))],
+        ));
+        ext.execute_with(|| {
+            let events: Vec<_> = db_events_at::<Test, Api>(H256::zero()).unwrap().collect();
+            assert_eq!(
+                events.len(),
+                3
+            );
+            assert!(matches!(
+                &events[0],
+                DBEvent::SchemaUpdated(None, list) if list.is_empty()
+            ));
+            assert!(matches!(
+                &events[1],
+                DBEvent::TableDropped(None, TableType::CoreBlockchain, ident, Source::Ethereum)
+                    if *ident == TableIdentifier::from_str_unchecked("TABLE1", "NAMESPACE")
+            ));
+            assert!(matches!(
+                &events[2],
+                DBEvent::QuorumReached { quorum, .. } if quorum.table == TableIdentifier::from_str_unchecked("TABLE2", "NAMESPACE")
+            ));
+        });
+    }
+}

--- a/pallets/prover_db_indexer/src/lib.rs
+++ b/pallets/prover_db_indexer/src/lib.rs
@@ -49,6 +49,8 @@ mod mock;
 #[cfg(test)]
 mod tests;
 
+#[expect(dead_code, reason = "Usage for this function is not yet implemented")]
+mod db_events;
 mod http_client;
 mod offchain_consumer;
 

--- a/pallets/prover_db_indexer/src/mock.rs
+++ b/pallets/prover_db_indexer/src/mock.rs
@@ -1,16 +1,29 @@
-//! Minimal mock runtime for testing the consumer (OCW HTTP forwarding).
-//!
-//! The pallet's `Config` only requires `frame_system::Config`, so the
-//! mock is intentionally tiny — frame-system + the pallet itself. Tests
-//! pre-populate the offchain DB with payload+high-water keys directly,
-//! then drive `offchain_worker` and assert on outbound HTTP traffic.
-
-use polkadot_sdk::frame_support::traits::ConstU64;
-use polkadot_sdk::frame_support::{construct_runtime, derive_impl};
+use native_api::Api;
+use polkadot_sdk::frame_election_provider_support::bounds::{
+    ElectionBounds,
+    ElectionBoundsBuilder,
+};
+use polkadot_sdk::frame_election_provider_support::{onchain, SequentialPhragmen};
+use polkadot_sdk::frame_support::pallet_prelude::ConstU32;
+use polkadot_sdk::frame_support::traits::{ConstU128, ConstU64};
+use polkadot_sdk::frame_support::{construct_runtime, derive_impl, parameter_types};
 use polkadot_sdk::sp_core::H256;
-use polkadot_sdk::sp_runtime::traits::IdentityLookup;
-use polkadot_sdk::sp_runtime::BuildStorage;
-use polkadot_sdk::{frame_system, sp_io, sp_runtime};
+use polkadot_sdk::sp_runtime::traits::{IdentityLookup, OpaqueKeys};
+use polkadot_sdk::sp_runtime::{BuildStorage, KeyTypeId};
+use polkadot_sdk::{
+    frame_system,
+    pallet_balances,
+    pallet_session,
+    pallet_staking,
+    pallet_staking_reward_curve,
+    pallet_timestamp,
+    sp_core,
+    sp_io,
+    sp_runtime,
+    sp_staking,
+};
+use proof_of_sql_commitment_map::generic_over_commitment::ConcreteType;
+use proof_of_sql_commitment_map::PerCommitmentScheme;
 
 use crate as pallet_prover_db_indexer;
 
@@ -19,20 +32,179 @@ type Block = frame_system::mocking::MockBlock<Test>;
 construct_runtime!(
     pub enum Test {
         System: frame_system,
+        Indexing: pallet_indexing::native_pallet,
+        Permissions: pallet_permissions,
+        Commitments: pallet_commitments,
+        ZkPay: pallet_zkpay,
+        Tables: pallet_tables,
+        Session: pallet_session,
+        SystemTables: pallet_system_tables,
+        Balances: pallet_balances,
+        Staking: pallet_staking,
         ProverDbIndexer: pallet_prover_db_indexer,
     }
 );
 
 type AccountId = sp_runtime::AccountId32;
 type Nonce = u32;
+type Balance = u128;
 
 #[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
 impl frame_system::Config for Test {
     type Nonce = Nonce;
     type AccountId = AccountId;
+    type AccountData = pallet_balances::AccountData<Balance>;
     type Block = Block;
     type Lookup = IdentityLookup<Self::AccountId>;
     type Hash = H256;
+}
+
+impl pallet_balances::Config for Test {
+    type AccountStore = System;
+    type Balance = Balance;
+    type RuntimeEvent = RuntimeEvent;
+    type RuntimeHoldReason = ();
+    type RuntimeFreezeReason = ();
+    type WeightInfo = ();
+    type DustRemoval = ();
+    type ExistentialDeposit = ConstU128<1>;
+    type ReserveIdentifier = ();
+    type FreezeIdentifier = ();
+    type MaxLocks = ();
+    type MaxReserves = ();
+    type MaxFreezes = ();
+}
+
+impl pallet_timestamp::Config for Test {
+    type Moment = u64;
+    type OnTimestampSet = ();
+    type MinimumPeriod = ConstU64<5>;
+    type WeightInfo = ();
+}
+
+pallet_staking_reward_curve::build! {
+    const I_NPOS: sp_runtime::curve::PiecewiseLinear<'static> = curve!(
+        min_inflation: 0_025_000,
+        max_inflation: 0_100_000,
+        ideal_stake: 0_500_000,
+        falloff: 0_050_000,
+        max_piece_count: 40,
+        test_precision: 0_005_000,
+    );
+}
+parameter_types! {
+    pub const RewardCurve: &'static sp_runtime::curve::PiecewiseLinear<'static> = &I_NPOS;
+    pub static ElectionsBounds: ElectionBounds = ElectionBoundsBuilder::default().build();
+}
+
+pub struct OnChainSeqPhragmen;
+impl onchain::Config for OnChainSeqPhragmen {
+    type System = Test;
+    type Solver = SequentialPhragmen<AccountId, sp_runtime::Perbill>;
+    type DataProvider = Staking;
+    type WeightInfo = ();
+    type MaxWinners = ConstU32<100>;
+    type Bounds = ElectionsBounds;
+}
+
+#[derive_impl(pallet_staking::config_preludes::TestDefaultConfig)]
+impl pallet_staking::Config for Test {
+    type Currency = Balances;
+    type CurrencyBalance = <Self as pallet_balances::Config>::Balance;
+    type UnixTime = pallet_timestamp::Pallet<Self>;
+    type AdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
+    type SessionInterface = Self;
+    type EraPayout = pallet_staking::ConvertCurve<RewardCurve>;
+    type NextNewSession = Session;
+    type ElectionProvider = onchain::OnChainExecution<OnChainSeqPhragmen>;
+    type GenesisElectionProvider = Self::ElectionProvider;
+    type VoterList = pallet_staking::UseNominatorsAndValidatorsMap<Self>;
+    type TargetList = pallet_staking::UseValidatorsMap<Self>;
+    type CurrencyToVote = sp_staking::currency_to_vote::U128CurrencyToVote;
+    type NominationsQuota = pallet_staking::FixedNominationsQuota<16>;
+    type RewardRemainder = (); // Reward Remainders are burned
+    type RuntimeEvent = RuntimeEvent;
+    type Slash = (); // Slashed funds will be burned
+    type Reward = (); // Rewards are minted not transferred
+    type MaxControllersInDeprecationBatch = ();
+    type EventListeners = (); // This will be needed if we add nomination pools
+    type DisablingStrategy = pallet_staking::UpToLimitDisablingStrategy;
+    type WeightInfo = pallet_staking::weights::SubstrateWeight<Test>;
+}
+
+impl pallet_indexing::pallet::Config<Api> for Test {
+    type RuntimeEvent = RuntimeEvent;
+    type WeightInfo = pallet_indexing::weights::SubstrateWeight<Test>;
+    type EventCapture = ();
+}
+pub type BlockNumber = u64;
+
+parameter_types! {
+    pub const Period: BlockNumber = 1;
+    pub const Offset: BlockNumber = 0;
+}
+
+pub struct TestSessionHandler;
+impl pallet_session::SessionHandler<AccountId> for TestSessionHandler {
+    const KEY_TYPE_IDS: &'static [KeyTypeId] = &[sp_core::crypto::key_types::DUMMY];
+
+    fn on_new_session<Ks: OpaqueKeys>(
+        _changed: bool,
+        _validators: &[(AccountId, Ks)],
+        _queued_validators: &[(AccountId, Ks)],
+    ) {
+    }
+
+    fn on_disabled(_validator_index: u32) {}
+
+    fn on_genesis_session<Ks: OpaqueKeys>(_validators: &[(AccountId, Ks)]) {}
+}
+
+impl pallet_session::Config for Test {
+    type SessionManager = ();
+    type Keys = sp_runtime::testing::UintAuthorityId;
+    type ShouldEndSession = pallet_session::PeriodicSessions<Period, Offset>;
+    type SessionHandler = TestSessionHandler;
+    type RuntimeEvent = RuntimeEvent;
+    type ValidatorId = AccountId;
+    type ValidatorIdOf = pallet_staking::StashOf<Test>;
+    type NextSessionRotation = pallet_session::PeriodicSessions<Period, Offset>;
+    type WeightInfo = ();
+}
+impl pallet_session::historical::Config for Test {
+    type FullIdentification = pallet_staking::Exposure<AccountId, Balance>;
+    type FullIdentificationOf = pallet_staking::ExposureOf<Test>;
+}
+
+sp_runtime::impl_opaque_keys! {
+    pub struct SessionKeys {
+        pub foo: sp_runtime::testing::UintAuthorityId,
+    }
+}
+
+impl pallet_zkpay::Config for Test {
+    type RuntimeEvent = RuntimeEvent;
+}
+
+impl pallet_system_tables::Config for Test {
+    type RuntimeEvent = RuntimeEvent;
+}
+
+impl pallet_tables::Config for Test {
+    type RuntimeEvent = RuntimeEvent;
+    type WeightInfo = ();
+    type EventCapture = ();
+}
+
+impl pallet_permissions::Config for Test {
+    type RuntimeEvent = RuntimeEvent;
+    type WeightInfo = ();
+}
+impl pallet_commitments::Config for Test {
+    const END_ROW_LIMITS_PER_SCHEME: PerCommitmentScheme<ConcreteType<u32>> = PerCommitmentScheme {
+        hyper_kzg: 4,
+        dynamic_dory: 4,
+    };
 }
 
 impl pallet_prover_db_indexer::Config for Test {
@@ -46,4 +218,61 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
         .build_storage()
         .unwrap()
         .into()
+}
+
+#[cfg(all(test, feature = "std"))]
+pub struct MockClientProvider {
+    pub finalized_state: Option<(H256, u32)>,
+    storage_responses: std::sync::Mutex<
+        std::collections::VecDeque<Result<Option<sp_core::storage::StorageData>, String>>,
+    >,
+}
+
+#[cfg(all(test, feature = "std"))]
+impl MockClientProvider {
+    /// Builds a client extension backed by a fresh `MockClientProvider`.
+    pub fn client_ext(
+        finalized_state: Option<(H256, u32)>,
+        storage_responses: impl IntoIterator<
+            Item = Result<Option<sp_core::storage::StorageData>, String>,
+        >,
+    ) -> native::client::ClientExt {
+        native::client::ClientExt(std::sync::Arc::new(Self {
+            finalized_state,
+            storage_responses: std::sync::Mutex::new(storage_responses.into_iter().collect()),
+        }))
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+impl native::client::ClientProvider for MockClientProvider {
+    fn finalized_state(&self) -> Option<(H256, u32)> {
+        self.finalized_state
+    }
+
+    fn storage(
+        &self,
+        _hash: H256,
+        _key: &sp_core::storage::StorageKey,
+    ) -> polkadot_sdk::sp_blockchain::Result<Option<sp_core::storage::StorageData>> {
+        self.storage_responses
+            .lock()
+            .unwrap()
+            .pop_front()
+            .unwrap_or(Ok(None))
+            .map_err(polkadot_sdk::sp_blockchain::Error::UnknownBlock)
+    }
+}
+
+/// Builds an `EventRecord` the way `frame_system` would have deposited it,
+/// for tests that seed `System::Events` storage bytes directly.
+#[cfg(all(test, feature = "std"))]
+pub fn event_record(
+    event: impl Into<RuntimeEvent>,
+) -> frame_system::EventRecord<RuntimeEvent, H256> {
+    frame_system::EventRecord {
+        phase: frame_system::Phase::Initialization,
+        event: event.into(),
+        topics: vec![],
+    }
 }


### PR DESCRIPTION
# Rationale for this change

The `prover_db_indexer` needs to collect DML and DDL events. 

# What changes are included in this PR?

This PR adds a helper that collects DML and DDL events from the native client so that an OCW can use them.

# Are these changes tested?

Yes