### PR TITLE
feat: add generic config key-value store for offchain workers

### DIFF
--- a/native/src/config.rs
+++ b/native/src/config.rs
@@ -1,0 +1,75 @@
+//! Native interface for configuration access.
+
+use alloc::string::String;
+
+use polkadot_sdk::sp_externalities::ExternalitiesExt;
+use polkadot_sdk::sp_runtime_interface::runtime_interface;
+
+/// A trait for providing configuration values.
+pub trait ConfigProvider: Send + Sync {
+    /// Given a key, return the value under that key in the node's configuration.
+    fn get(&self, key: &str) -> Option<String>;
+}
+
+#[cfg(feature = "std")]
+impl ConfigProvider for std::collections::HashMap<String, String> {
+    fn get(&self, key: &str) -> Option<String> {
+        std::collections::HashMap::get(self, key).cloned()
+    }
+}
+
+#[cfg(feature = "std")]
+polkadot_sdk::sp_externalities::decl_extension! {
+    /// Externalities extension exposing the node's configuration.
+    pub struct ConfigExt(std::sync::Arc<dyn ConfigProvider>);
+}
+
+/// Native code interface onto the node's configuration, exposed via the [`ConfigExt`] externalities extension.
+#[runtime_interface]
+pub trait Config {
+    /// Given a key, return the value under that key in the node's configuration.
+    fn get(&mut self, key: &str) -> Option<Option<String>> {
+        ExternalitiesExt::extension(self).map(|ConfigExt(provider)| provider.get(key))
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use polkadot_sdk::sp_io::TestExternalities;
+
+    use super::*;
+
+    #[test]
+    fn get_is_none_when_extension_not_registered() {
+        let mut ext = TestExternalities::default();
+        ext.execute_with(|| {
+            assert_eq!(config::get("some-key"), None);
+        });
+    }
+
+    #[test]
+    fn get_is_some_none_when_key_is_absent() {
+        let mut ext = TestExternalities::default();
+        ext.register_extension(ConfigExt(Arc::new(HashMap::new())));
+        ext.execute_with(|| {
+            assert_eq!(config::get("missing-key"), Some(None));
+        });
+    }
+
+    #[test]
+    fn get_forwards_registered_value() {
+        let mut ext = TestExternalities::default();
+        let mut map = HashMap::new();
+        map.insert("some-key".to_string(), "some-value".to_string());
+        ext.register_extension(ConfigExt(Arc::new(map)));
+        ext.execute_with(|| {
+            assert_eq!(
+                config::get("some-key"),
+                Some(Some("some-value".to_string()))
+            );
+        });
+    }
+}

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -6,6 +6,8 @@ extern crate alloc;
 /// Extension giving offchain workers read access to the node's client, and the
 /// runtime interface exposing it to the runtime.
 pub mod client;
+
+pub mod config;
 /// The space and time native code interface
 mod sxt;
 

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -1,6 +1,7 @@
 use polkadot_sdk::sc_cli::RunCmd;
 use polkadot_sdk::{frame_benchmarking_cli, sc_cli, sc_storage_monitor};
 use proof_of_sql_static_setups::io::ProofOfSqlPublicSetupArgs;
+use snafu::{OptionExt, Snafu};
 
 #[derive(Debug, clap::Parser)]
 pub struct Cli {
@@ -33,6 +34,24 @@ pub struct Cli {
     /// Configuration for loading proof-of-sql public setups.
     #[clap(flatten)]
     pub proof_of_sql_public_setup_args: ProofOfSqlPublicSetupArgs,
+
+    /// Node-local `KEY=VALUE` configuration entries, exposed to offchain
+    /// workers via the `native::config` runtime interface. Repeat the flag once per entry.
+    #[clap(long, value_parser = parse_key_val)]
+    pub ocw_config: Vec<(String, String)>,
+}
+
+/// Error parsing a `KEY=VALUE` entry.
+#[derive(Debug, Snafu, PartialEq)]
+#[snafu(display("expected 'KEY=VALUE', got '{s}'"))]
+pub struct ParseKeyValError {
+    s: String,
+}
+
+fn parse_key_val(s: &str) -> Result<(String, String), ParseKeyValError> {
+    s.split_once('=')
+        .context(ParseKeyValSnafu { s })
+        .map(|(k, v)| (k.to_owned(), v.to_owned()))
 }
 
 /// Flattened consumer-side configuration. Lives on the top-level
@@ -111,4 +130,28 @@ pub enum Subcommand {
 
     /// Db meta columns information.
     ChainInfo(sc_cli::ChainInfoCmd),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_key_val, ParseKeyValError};
+
+    #[test]
+    fn we_can_parse_key_val() {
+        assert_eq!(
+            parse_key_val("cfg"),
+            Err(ParseKeyValError {
+                s: "cfg".to_owned()
+            })
+        );
+        assert_eq!(parse_key_val("cfg="), Ok(("cfg".to_owned(), "".to_owned())));
+        assert_eq!(
+            parse_key_val("cfg=foo"),
+            Ok(("cfg".to_owned(), "foo".to_owned()))
+        );
+        assert_eq!(
+            parse_key_val("cfg=foo=bar"),
+            Ok(("cfg".to_owned(), "foo=bar".to_owned()))
+        );
+    }
 }

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -1,5 +1,6 @@
 //! Service and ServiceFactory implementation. Specialized wrapper over substrate service.
 
+use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -52,6 +53,7 @@ pub type HostFunctions = (
     sp_statement_store::runtime_api::HostFunctions,
     native::interface::HostFunctions,
     native::client::client::HostFunctions,
+    native::config::config::HostFunctions,
 );
 
 #[cfg(feature = "runtime-benchmarks")]
@@ -60,6 +62,7 @@ pub type HostFunctions = (
     sp_statement_store::runtime_api::HostFunctions,
     native::interface::HostFunctions,
     native::client::client::HostFunctions,
+    native::config::config::HostFunctions,
     polkadot_sdk::frame_benchmarking::benchmarking::HostFunctions,
 );
 
@@ -620,6 +623,8 @@ pub fn new_full_base<N: NetworkBackend<Block, <Block as BlockT>::Hash>>(
     );
 
     if enable_offchain_worker {
+        let client_provider = Arc::new(crate::client_provider::FullClientHandle(client.clone()));
+        let config_store = Arc::new(HashMap::from_iter(cli.ocw_config.iter().cloned()));
         task_manager.spawn_handle().spawn(
             "offchain-workers-runner",
             "offchain-work",
@@ -633,15 +638,12 @@ pub fn new_full_base<N: NetworkBackend<Block, <Block as BlockT>::Hash>>(
                 network_provider: Arc::new(network.clone()),
                 is_validator: role.is_authority(),
                 enable_http_requests: true,
-                custom_extensions: {
-                    let provider =
-                        Arc::new(crate::client_provider::FullClientHandle(client.clone()));
-                    move |_| {
-                        vec![
-                            Box::new(statement_store.clone().as_statement_store_ext()) as Box<_>,
-                            Box::new(native::client::ClientExt(provider.clone())) as Box<_>,
-                        ]
-                    }
+                custom_extensions: move |_| {
+                    vec![
+                        Box::new(statement_store.clone().as_statement_store_ext()) as Box<_>,
+                        Box::new(native::client::ClientExt(client_provider.clone())) as Box<_>,
+                        Box::new(native::config::ConfigExt(config_store.clone())) as Box<_>,
+                    ]
                 },
             })
             .run(client.clone(), task_manager.spawn_handle())

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.91.1"
 targets = ["wasm32-unknown-unknown"]
-components = ["rust-src"]
+components = ["rust-src", "rust-analyzer"]


### PR DESCRIPTION
# Rationale for this change

We want to be able to allow node operators to provide deployment specific configuration values to offchain workers. Instead of using custom CLI args that necessitate coordination between node and runtime versions, we introduce a single pass-through configuration.

# Are these changes tested?

Yes