### PR TITLE
feat: use generic key value config for `prover_db_indexing`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21181,6 +21181,7 @@ dependencies = [
  "sp-runtime-interface",
  "sqlparser",
  "subxt",
+ "url",
 ]
 
 [[package]]
@@ -21208,7 +21209,6 @@ dependencies = [
  "substrate-build-script-utils",
  "sxt-core",
  "sxt-runtime",
- "url",
 ]
 
 [[package]]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -46,7 +46,6 @@ rand.workspace = true
 node-rpc.workspace = true
 serde.workspace = true
 codec = { workspace = true, default-features = true }
-url = { workspace = true }
 
 [build-dependencies]
 substrate-build-script-utils.workspace = true

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -20,13 +20,6 @@ pub struct Cli {
     #[clap(long)]
     pub event_forwarder_rpc: Option<String>,
 
-    /// Prover-db consumer settings. Setting `--prover-db-url` is what
-    /// turns this node into a prover-db indexer; the other fields in
-    /// the group only take effect when the URL is set. See the field
-    /// docs on [`ProverDbConsumerCli`] for grammar.
-    #[clap(flatten)]
-    pub prover_db: ProverDbConsumerCli,
-
     #[allow(missing_docs)]
     #[clap(flatten)]
     pub storage_monitor: sc_storage_monitor::StorageMonitorParams,
@@ -52,48 +45,6 @@ fn parse_key_val(s: &str) -> Result<(String, String), ParseKeyValError> {
     s.split_once('=')
         .context(ParseKeyValSnafu { s })
         .map(|(k, v)| (k.to_owned(), v.to_owned()))
-}
-
-/// Flattened consumer-side configuration. Lives on the top-level
-/// `Cli` via `#[clap(flatten)]`. Validated at service init into
-/// `sxt_core::prover_db_indexer::ProverDbConsumerConfig` before being
-/// written to offchain local storage; see
-/// `service::configure_prover_db_consumer`.
-///
-/// On the CLI side the fields are individually optional / repeatable —
-/// clap can't express "if URL is set, the group is active" in the type.
-/// The resolver in `service.rs` enforces that constraint and produces a
-/// concrete `ProverDbConsumerConfig` (URL non-optional) or refuses to
-/// start.
-#[derive(Debug, clap::Args)]
-pub struct ProverDbConsumerCli {
-    /// URL of the prover-db indexer to forward indexed events to.
-    /// Also configurable via the `PROVER_DB_URL` env var.
-    ///
-    /// Presence of this flag is what enables the consumer. If omitted,
-    /// the OCW stays dormant regardless of `--prover-db-include`.
-    #[clap(long, env)]
-    pub prover_db_url: Option<url::Url>,
-
-    /// Wildcard patterns naming which tables this node should forward
-    /// to the indexer. Repeat the flag, or pass a single comma-
-    /// separated value, or set `PROVER_DB_INCLUDE`.
-    ///
-    /// Each entry parses as a [`TableIdentifierFilter`]: two
-    /// dot-separated sides, each either a literal identifier or `*`.
-    /// Both sides match independently, so:
-    ///   - `*.*`             — every captured event (default if omitted).
-    ///   - `NAMESPACE.*`     — every table in NAMESPACE.
-    ///   - `*.NAME`          — every table called NAME, regardless of namespace.
-    ///   - `NAMESPACE.NAME`  — exactly that one table.
-    ///
-    /// Identifiers are uppercased before being written to offchain
-    /// storage so the byte-match against the on-chain canonical form
-    /// works without per-operator vigilance.
-    ///
-    /// [`TableIdentifierFilter`]: sxt_core::prover_db_indexer::TableIdentifierFilter
-    #[clap(long, env, value_delimiter = ',', default_value = "*.*")]
-    pub prover_db_include: Vec<sxt_core::prover_db_indexer::TableIdentifierFilter>,
 }
 
 #[derive(Debug, clap::Subcommand)]

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
-use codec::Encode;
 use futures::prelude::*;
 use polkadot_sdk::sc_client_api::{Backend, BlockBackend};
 use polkadot_sdk::sc_consensus_babe::{self, SlotProportion};
@@ -16,7 +15,6 @@ use polkadot_sdk::sc_service::error::Error as ServiceError;
 use polkadot_sdk::sc_service::TaskManager;
 use polkadot_sdk::sc_telemetry::{Telemetry, TelemetryWorker};
 use polkadot_sdk::sc_transaction_pool_api::OffchainTransactionPoolFactory;
-use polkadot_sdk::sp_core::offchain::{OffchainStorage, STORAGE_PREFIX};
 use polkadot_sdk::sp_runtime::traits::Block as BlockT;
 use polkadot_sdk::{
     sc_authority_discovery,
@@ -81,47 +79,6 @@ pub type TransactionPool = sc_transaction_pool::FullPool<Block, FullClient>;
 /// The minimum period of blocks on which justifications will be
 /// imported and generated.
 const GRANDPA_JUSTIFICATION_PERIOD: u32 = 512;
-
-/// Validate the consumer CLI group into a concrete
-/// `ProverDbConsumerConfig` (URL non-optional) and seed it under
-/// `PROVER_DB_CONFIG_KEY` in offchain persistent local storage.
-///
-/// `--prover-db-url` is the single switch that enables the consumer:
-/// present ⇒ write the config; absent ⇒ the OCW stays dormant and we
-/// don't write anything. `--prover-db-include` is allowed (with its
-/// `*.*` default) regardless of whether the URL is set; without a URL
-/// it just has nothing to filter.
-#[expect(
-    clippy::result_large_err,
-    reason = "ServiceError is from substrate and cannot be modified"
-)]
-fn configure_prover_db_consumer(
-    backend: &FullBackend,
-    cli: &crate::cli::ProverDbConsumerCli,
-) -> Result<(), ServiceError> {
-    let Some(url) = cli.prover_db_url.as_ref() else {
-        return Ok(());
-    };
-
-    let cfg = sxt_core::prover_db_indexer::ProverDbConsumerConfig {
-        url: url.as_str().to_string(),
-        include: cli.prover_db_include.clone(),
-    };
-
-    let Some(mut storage) = backend.offchain_storage() else {
-        return Err(ServiceError::Other(
-            "backend did not expose an offchain storage handle; \
-             cannot apply --prover-db-url / --prover-db-include"
-                .into(),
-        ));
-    };
-    storage.set(
-        STORAGE_PREFIX,
-        sxt_core::prover_db_indexer::PROVER_DB_CONFIG_KEY,
-        &cfg.encode(),
-    );
-    Ok(())
-}
 
 #[allow(clippy::type_complexity)]
 #[expect(
@@ -370,21 +327,6 @@ pub fn new_full_base<N: NetworkBackend<Block, <Block as BlockT>::Hash>>(
         transaction_pool,
         other: (rpc_builder, import_setup, rpc_setup, mut telemetry, statement_store),
     } = new_partial(&config)?;
-
-    // The prover-db consumer (URL + include set) only takes effect when
-    // offchain indexing is enabled, since the OCW only runs in that
-    // case. Fail loud if the operator set --prover-db-url without
-    // enabling indexing, rather than silently ignoring it.
-    if cli.prover_db.prover_db_url.is_some() && !config.offchain_worker.indexing_enabled {
-        return Err(ServiceError::Other(
-            "--prover-db-url was set but --enable-offchain-indexing is not \
-             true; the prover-db-indexer offchain worker would be inactive. \
-             Restart with --enable-offchain-indexing=true, or omit \
-             --prover-db-url."
-                .into(),
-        ));
-    }
-    configure_prover_db_consumer(backend.as_ref(), &cli.prover_db)?;
 
     let metrics = N::register_notification_metrics(
         config.prometheus_config.as_ref().map(|cfg| &cfg.registry),

--- a/pallets/prover_db_indexer/src/lib.rs
+++ b/pallets/prover_db_indexer/src/lib.rs
@@ -60,9 +60,6 @@ mod proto {
 }
 
 pub use pallet::*;
-/// Re-export of the canonical offchain local-storage key (defined in `sxt-core`),
-/// so the node service and any external tooling have a single import.
-pub use sxt_core::prover_db_indexer::PROVER_DB_CONFIG_KEY;
 
 /// Offchain DB key for the lock that serializes OCW consumer rounds.
 const OCW_LOCK_KEY: &[u8] = b"prover_db_indexer/ocw_lock";
@@ -78,11 +75,11 @@ const OCW_LOCK_KEY: &[u8] = b"prover_db_indexer/ocw_lock";
 /// every variant looks the same.
 #[derive(Debug, snafu::Snafu)]
 pub enum ConsumerError {
-    /// The configured indexer URL couldn't be parsed.
-    #[snafu(display("indexer URL is not a valid URL: {error}"))]
-    InvalidUrl {
-        /// Underlying parse error from the `url` crate.
-        error: url::ParseError,
+    /// Building the consumer configuration from node-supplied config failed.
+    #[snafu(transparent)]
+    Config {
+        /// Underlying config-parsing error.
+        source: sxt_core::prover_db_indexer::ProverDbConsumerConfigError,
     },
     /// The runtime's `BlockNumber` didn't fit in `u64` (defensive — in
     /// practice `BlockNumber` is `u32` so this is unreachable).
@@ -145,7 +142,6 @@ pub mod pallet {
     use polkadot_sdk::frame_system;
     use polkadot_sdk::frame_system::pallet_prelude::*;
     use polkadot_sdk::sp_core::H256;
-    use polkadot_sdk::sp_runtime::offchain::storage::StorageValueRef;
     use polkadot_sdk::sp_runtime::offchain::storage_lock::{StorageLock, Time};
     use polkadot_sdk::sp_runtime::offchain::Duration;
     use polkadot_sdk::sp_runtime::traits::CheckedConversion;
@@ -166,23 +162,7 @@ pub mod pallet {
     pub struct Pallet<T>(_);
 
     #[pallet::config]
-    pub trait Config: polkadot_sdk::frame_system::Config<Hash = H256> {
-        /// Maximum number of blocks the OCW will walk in a single
-        /// invocation. Controls catch-up speed: with 6s block time and
-        /// the default of 100, catch-up is ~100x realtime. Lower values
-        /// keep the per-round cost bounded; higher values close a wider
-        /// gap faster after downtime.
-        #[pallet::constant]
-        type MaxBlocksPerInvocation: Get<u64>;
-
-        /// How long (in milliseconds) a held OCW lock stays valid before
-        /// being treated as abandoned (e.g. node crashed mid-round). Must
-        /// comfortably cover one full consumer round under normal
-        /// conditions while still letting the chain recover quickly from
-        /// a crashed validator.
-        #[pallet::constant]
-        type OcwLockDeadlineMs: Get<u64>;
-    }
+    pub trait Config: polkadot_sdk::frame_system::Config<Hash = H256> {}
 
     #[pallet::hooks]
     impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
@@ -234,6 +214,7 @@ pub mod pallet {
         // ═══════════════════════════════════════════════════════════════
 
         fn run_consumer() -> Result<(), ConsumerError> {
+            let config = ProverDbConsumerConfig::try_from_map(native::config::config::get)?;
             // Serialize concurrent OCW invocations. Substrate spawns
             // `offchain_worker` for every imported block, and rounds can
             // overlap if one runs longer than block time. Without a lock,
@@ -244,28 +225,16 @@ pub mod pallet {
             // makes overlapping invocations no-ops.
             let mut lock = StorageLock::<Time>::with_deadline(
                 crate::OCW_LOCK_KEY,
-                Duration::from_millis(T::OcwLockDeadlineMs::get()),
+                Duration::from_millis(config.ocw_lock_deadline_ms),
             );
             let _guard = lock
                 .try_lock()
                 .map_err(|_| ConsumerError::ConsumerInProgress)?;
 
-            // 1. Read the single offchain config. Absence ⇒ this node
-            //    isn't an indexer; OCW is dormant. The node service
-            //    writes the encoded `ProverDbConsumerConfig` at startup
-            //    iff `--prover-db-url` was provided.
-            let cfg_ref = StorageValueRef::persistent(crate::PROVER_DB_CONFIG_KEY);
-            let Some(cfg) = cfg_ref.get::<ProverDbConsumerConfig>().ok().flatten() else {
-                return Ok(());
-            };
-            let url =
-                url::Url::parse(&cfg.url).map_err(|error| ConsumerError::InvalidUrl { error })?;
-            let include_filters: Vec<TableIdentifierFilter> = cfg.include;
-
             polkadot_sdk::sp_tracing::debug!(
                 target: "prover_db_indexer",
                 "consumer round starting; indexer base URL = {}; {} include filters",
-                url, include_filters.len(),
+                config.url, config.include.len(),
             );
 
             let (finalized_block_hash, finalized_block_num) =
@@ -280,7 +249,7 @@ pub mod pallet {
                 return Err(ConsumerError::FinalizedBlockHashMismatch);
             }
 
-            let cursor: u64 = crate::http_client::get_last_checkpoint(&url)
+            let cursor: u64 = crate::http_client::get_last_checkpoint(&config.url)
                 .map_err(|error| ConsumerError::GetLastCheckpoint { error })?
                 .unwrap_or(0);
 
@@ -292,12 +261,12 @@ pub mod pallet {
 
             for block_num in (cursor..=u64::from(finalized_block_num))
                 .skip(1)
-                .take(T::MaxBlocksPerInvocation::get().saturated_into())
+                .take(config.max_blocks_per_invocation)
             {
-                Self::forward_block(&url, block_num, &include_filters)?;
+                Self::forward_block(&config.url, block_num, &config.include)?;
 
                 // Checkpoint on the server (always, even for empty blocks).
-                crate::http_client::checkpoint(&url, block_num)
+                crate::http_client::checkpoint(&config.url, block_num)
                     .map_err(|error| ConsumerError::Checkpoint { error })?;
             }
 

--- a/pallets/prover_db_indexer/src/mock.rs
+++ b/pallets/prover_db_indexer/src/mock.rs
@@ -207,11 +207,7 @@ impl pallet_commitments::Config for Test {
     };
 }
 
-impl pallet_prover_db_indexer::Config for Test {
-    // Match runtime defaults so tests exercise the production limits.
-    type MaxBlocksPerInvocation = ConstU64<100>;
-    type OcwLockDeadlineMs = ConstU64<120_000>;
-}
+impl pallet_prover_db_indexer::Config for Test {}
 
 pub fn new_test_ext() -> sp_io::TestExternalities {
     frame_system::GenesisConfig::<Test>::default()

--- a/pallets/prover_db_indexer/src/tests.rs
+++ b/pallets/prover_db_indexer/src/tests.rs
@@ -24,27 +24,18 @@ use sxt_core::prover_db_indexer::{
     CreateEntry,
     EventCapture,
     InsertEntry,
-    ProverDbConsumerConfig,
-    TableIdentifierFilter,
+    PROVER_DB_CONFIG_INCLUDE_KEY,
+    PROVER_DB_CONFIG_URL_KEY,
 };
 use sxt_core::tables::TableIdentifier;
 
 use crate::mock::*;
-use crate::{proto, PROVER_DB_CONFIG_KEY};
+use crate::proto;
 
 type StateArc =
     std::sync::Arc<parking_lot::RwLock<polkadot_sdk::sp_core::offchain::testing::OffchainState>>;
 
 const MOCK_URL: &str = "http://127.0.0.1:9999";
-
-/// SCALE-encode the unified consumer config the same way the node
-/// service does at startup.
-fn encode_config(include: Vec<TableIdentifierFilter>) -> Vec<u8> {
-    codec::Encode::encode(&ProverDbConsumerConfig {
-        url: MOCK_URL.to_string(),
-        include,
-    })
-}
 
 fn expected_request(path: &str, body: Vec<u8>, response: Vec<u8>) -> PendingRequest {
     PendingRequest {
@@ -74,17 +65,14 @@ fn no_checkpoint_response() -> Vec<u8> {
     .encode_to_vec()
 }
 
-/// Seed a `*.*` filter — what the operator gets when omitting
-/// `--prover-db-include` (clap default). Every captured event should
-/// reach the indexer.
+/// Set a `*.*` filter.
 fn setup_with_url(finalized_block_num: u32) -> (polkadot_sdk::sp_io::TestExternalities, StateArc) {
-    setup_with_config(vec!["*.*".parse().unwrap()], finalized_block_num)
+    setup_with_config("*.*", finalized_block_num)
 }
 
-/// Seed a non-empty include set under the unified config key. Used by
-/// the consumer-side filter tests.
+/// Set a non-empty include set. Used by the consumer-side filter tests.
 fn setup_with_config(
-    include: Vec<TableIdentifierFilter>,
+    filters: &str,
     finalized_block_num: u32,
 ) -> (polkadot_sdk::sp_io::TestExternalities, StateArc) {
     let mut ext = new_test_ext();
@@ -95,10 +83,13 @@ fn setup_with_config(
         Some((H256::zero(), finalized_block_num)),
         [],
     ));
-    state
-        .write()
-        .persistent_storage
-        .set(b"", PROVER_DB_CONFIG_KEY, &encode_config(include));
+    let mut config_store = std::collections::HashMap::new();
+    config_store.insert(PROVER_DB_CONFIG_URL_KEY.to_string(), MOCK_URL.to_string());
+    config_store.insert(
+        PROVER_DB_CONFIG_INCLUDE_KEY.to_string(),
+        filters.to_string(),
+    );
+    ext.register_extension(native::config::ConfigExt(std::sync::Arc::new(config_store)));
     (ext, state)
 }
 
@@ -480,13 +471,7 @@ fn ocw_forwards_only_events_matching_include_set() {
     // service writes both URL + include atomically via a single
     // SCALE-encoded `ProverDbConsumerConfig` — same shape this test
     // mirrors.
-    let (mut ext, state) = setup_with_config(
-        vec![
-            "ALPHA.*".parse().unwrap(),
-            "BETA_NS.BETA_T".parse().unwrap(),
-        ],
-        1,
-    );
+    let (mut ext, state) = setup_with_config("ALPHA.*,BETA_NS.BETA_T", 1);
 
     // Block 1, extrinsic 0: a mix of matching and non-matching events.
     seed_block_events(
@@ -620,7 +605,7 @@ fn ocw_with_wildcard_filter_forwards_everything() {
 /// is the assertion.
 #[test]
 fn ocw_with_empty_include_set_forwards_nothing() {
-    let (mut ext, state) = setup_with_config(Vec::new(), 1);
+    let (mut ext, state) = setup_with_config("", 1);
 
     let ddl = b"CREATE TABLE ANY.ANY (ID BIGINT NOT NULL)";
     seed_block_events(

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -894,10 +894,7 @@ impl pallet_rewards::Config for Runtime {
     type MaxPayoutsPerBlock = ConstU32<3>;
 }
 
-impl pallet_prover_db_indexer::Config for Runtime {
-    type MaxBlocksPerInvocation = ConstU64<100>;
-    type OcwLockDeadlineMs = ConstU64<120_000>;
-}
+impl pallet_prover_db_indexer::Config for Runtime {}
 
 #[cfg(feature = "runtime-benchmarks")]
 impl frame_system_benchmarking::Config for Runtime {}

--- a/sxt-core/Cargo.toml
+++ b/sxt-core/Cargo.toml
@@ -41,6 +41,7 @@ rand_chacha = { workspace = true, default-features = false }
 proptest = { workspace = true, features = ["std"], optional = true }
 proptest-derive = { workspace = true, optional = true }
 arrow-ipc-no-std.workspace = true
+url = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true, features = ["std"] }
@@ -60,7 +61,8 @@ std = [
 	"on-chain-table/arrow",
 	"scale-info/std",
 	"dep:arrow",
-        "dep:subxt",
+    "dep:subxt",
+	"url/std",
 ]
 runtime-benchmarks = []
 proptest = ["std", "dep:proptest", "on-chain-table/proptest", "dep:proptest-derive"]

--- a/sxt-core/src/prover_db_indexer.rs
+++ b/sxt-core/src/prover_db_indexer.rs
@@ -1,49 +1,141 @@
 //! Shared items for the prover-db-indexer pallet, the node service
-//! that seeds its configuration, and the producer call sites in
+//! that supplies its configuration, and the producer call sites in
 //! `pallet-tables` and `pallet-indexing`.
 
 use alloc::borrow::Cow;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
+use core::num::ParseIntError;
 use core::str::FromStr;
 
 use codec::{Decode, Encode};
-use snafu::Snafu;
+use snafu::{OptionExt, ResultExt, Snafu};
+use url::Url;
 
 use crate::tables::TableIdentifier;
 use crate::IDENT_LENGTH;
 
-/// Offchain local-storage key holding the prover-db indexer consumer's
-/// configuration. The embedding node writes a SCALE-encoded
-/// [`ProverDbConsumerConfig`] under this key at startup; the OCW reads
-/// it once per round. Absence of the key means "OCW is dormant".
-///
-/// One key for the whole consumer rather than one-per-field so the
-/// "consumer is enabled" and "consumer is disabled with stale filter
-/// settings" states are unrepresentable.
-pub const PROVER_DB_CONFIG_KEY: &[u8] = b"prover_db_indexer/consumer_config";
+/// Config key holding the prover-db indexer's target URL.
+pub const PROVER_DB_CONFIG_URL_KEY: &str = "prover_db_indexer/url";
 
-/// Per-node configuration that turns this node into a prover-db
-/// indexer: the upstream URL to POST forwarded events to, plus the
-/// optional include set that gates which events get forwarded.
-///
-/// Lives in offchain local storage under [`PROVER_DB_CONFIG_KEY`].
-/// `url` is non-optional: writing the config _is_ the act of enabling
-/// the consumer, and there's no enabled-without-URL state to express.
-/// `include` may be empty, which the OCW treats as "match every table"
-/// (same default as if the operator hadn't passed any include patterns
-/// at all).
-#[derive(Encode, Decode, Debug, Clone, Eq, PartialEq)]
+/// Config key holding the comma-separated `NAMESPACE.NAME` include filters.
+pub const PROVER_DB_CONFIG_INCLUDE_KEY: &str = "prover_db_indexer/include";
+
+/// Config key overriding [`DEFAULT_MAX_BLOCKS_PER_INVOCATION`].
+pub const MAX_BLOCKS_PER_INVOCATION_CONFIG_KEY: &str =
+    "prover_db_indexer/max_blocks_per_invocation";
+
+/// Default cap on blocks walked per OCW invocation.
+pub const DEFAULT_MAX_BLOCKS_PER_INVOCATION: usize = 100;
+
+/// Config key overriding [`DEFAULT_OCW_LOCK_DEADLINE_MS`].
+pub const OCW_LOCK_DEADLINE_MS_CONFIG_KEY: &str = "prover_db_indexer/ocw_lock_deadline_ms";
+
+/// Default OCW storage lock deadline, in milliseconds.
+pub const DEFAULT_OCW_LOCK_DEADLINE_MS: u64 = 120_000;
+
+/// Runtime configuration for the prover-db OCW consumer.
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ProverDbConsumerConfig {
-    /// HTTP base URL of the upstream prover-db indexer. Validated at
-    /// node start; stored as raw bytes so the pallet doesn't need to
-    /// pull in the `url` crate's full parsing surface.
-    pub url: String,
+    /// HTTP base URL of the upstream prover-db indexer.
+    pub url: Url,
     /// Per-node include set. An event is forwarded iff its
     /// `TableIdentifier` matches at least one filter. Empty ⇒ forward
     /// nothing; callers that want "forward everything" must include an
     /// explicit `*.*` filter.
     pub include: Vec<TableIdentifierFilter>,
+    /// Cap on blocks walked per OCW invocation.
+    pub max_blocks_per_invocation: usize,
+    /// OCW storage lock deadline, in milliseconds.
+    pub ocw_lock_deadline_ms: u64,
+}
+
+/// Errors from building a [`ProverDbConsumerConfig`] out of raw config strings.
+#[derive(Debug, Snafu)]
+pub enum ProverDbConsumerConfigError {
+    /// Config externality not registered.
+    #[snafu(display("config externality not registered"))]
+    NotRegistered,
+    /// [`PROVER_DB_CONFIG_URL_KEY`] is not set in the configuration.
+    #[snafu(display("configuration key '{PROVER_DB_CONFIG_URL_KEY}' is not set"))]
+    MissingUrl,
+    /// The configured URL failed to parse.
+    #[snafu(display(
+        "failed to parse value provided for '{PROVER_DB_CONFIG_URL_KEY}' key: {error}"
+    ))]
+    ParseUrl {
+        /// Underlying parse error from the `url` crate.
+        error: url::ParseError,
+    },
+    /// The configured include filter set failed to parse.
+    #[snafu(display(
+        "failed to parse value provided for '{PROVER_DB_CONFIG_INCLUDE_KEY}' key: {source}"
+    ))]
+    ParseFilter {
+        /// Underlying [`TableIdentifierFilter`] parse error.
+        source: TableIdentifierFilterParseError,
+    },
+    /// [`MAX_BLOCKS_PER_INVOCATION_CONFIG_KEY`] failed to parse as a `usize`.
+    #[snafu(display(
+        "failed to parse value provided for '{MAX_BLOCKS_PER_INVOCATION_CONFIG_KEY}' key: {source}"
+    ))]
+    ParseMaxBlocks {
+        /// Underlying integer parse error.
+        source: ParseIntError,
+    },
+    /// [`OCW_LOCK_DEADLINE_MS_CONFIG_KEY`] failed to parse as a `u64`.
+    #[snafu(display(
+        "failed to parse value provided for '{OCW_LOCK_DEADLINE_MS_CONFIG_KEY}' key: {source}"
+    ))]
+    ParseLockDeadline {
+        /// Underlying integer parse error.
+        source: ParseIntError,
+    },
+}
+
+impl ProverDbConsumerConfig {
+    /// Builds a config by looking up each setting via `get`, where
+    /// `get(key)` returns `None` if `key` isn't registered at all, or
+    /// `Some(None)` if it's registered but unset.
+    pub fn try_from_map<F: Fn(&str) -> Option<Option<String>>>(
+        get: F,
+    ) -> Result<Self, ProverDbConsumerConfigError> {
+        let url = get(PROVER_DB_CONFIG_URL_KEY)
+            .context(NotRegisteredSnafu)?
+            .context(MissingUrlSnafu)?
+            .parse()
+            .map_err(|error| ProverDbConsumerConfigError::ParseUrl { error })?;
+        let include = get(PROVER_DB_CONFIG_INCLUDE_KEY)
+            .context(NotRegisteredSnafu)?
+            .map(|s| {
+                if s.is_empty() {
+                    Ok(Vec::new())
+                } else {
+                    s.split(',').map(str::parse).collect::<Result<_, _>>()
+                }
+            })
+            .transpose()
+            .context(ParseFilterSnafu)?
+            .unwrap_or_default();
+        let max_blocks_per_invocation = get(MAX_BLOCKS_PER_INVOCATION_CONFIG_KEY)
+            .context(NotRegisteredSnafu)?
+            .map(|s| s.parse())
+            .transpose()
+            .context(ParseMaxBlocksSnafu)?
+            .unwrap_or(DEFAULT_MAX_BLOCKS_PER_INVOCATION);
+        let ocw_lock_deadline_ms = get(OCW_LOCK_DEADLINE_MS_CONFIG_KEY)
+            .context(NotRegisteredSnafu)?
+            .map(|s| s.parse())
+            .transpose()
+            .context(ParseLockDeadlineSnafu)?
+            .unwrap_or(DEFAULT_OCW_LOCK_DEADLINE_MS);
+        Ok(ProverDbConsumerConfig {
+            url,
+            include,
+            max_blocks_per_invocation,
+            ocw_lock_deadline_ms,
+        })
+    }
 }
 
 /// Offchain DB key prefix for per-extrinsic event payloads. SCALE-encoded
@@ -200,10 +292,6 @@ impl FromStr for IdentFilter {
 /// both sides match — so `*.*` is "everything", `NS.*` is "every table
 /// in NS", `NS.NAME` is exact, and `*.NAME` is "any namespace, this
 /// name".
-///
-/// Stored only in the indexer node's offchain local storage (as the
-/// `include` field of [`ProverDbConsumerConfig`]); not part of on-chain
-/// state. An empty list matches nothing — see [`table_matches_filters`].
 #[derive(Encode, Decode, Debug, Clone, Eq, PartialEq)]
 pub struct TableIdentifierFilter {
     /// Filter applied to `ident.namespace`.
@@ -285,6 +373,142 @@ mod tests {
 
     fn ident(name: &str, namespace: &str) -> TableIdentifier {
         TableIdentifier::from_str_unchecked(name, namespace)
+    }
+
+    // ── ProverDbConsumerConfig::try_from_map ─────────────────────────
+
+    /// Builds a `get` closure from an explicit key list. A key absent
+    /// from `entries` is "not registered" (`None`); a key present with
+    /// value `None` is "registered but unset" (`Some(None)`).
+    fn make_get(
+        entries: &'static [(&'static str, Option<&'static str>)],
+    ) -> impl Fn(&str) -> Option<Option<String>> {
+        move |key| {
+            entries
+                .iter()
+                .find(|(k, _)| *k == key)
+                .map(|(_, v)| v.map(String::from))
+        }
+    }
+
+    #[test]
+    fn try_from_map_fails_when_not_registered() {
+        assert!(matches!(
+            ProverDbConsumerConfig::try_from_map(make_get(&[])),
+            Err(ProverDbConsumerConfigError::NotRegistered),
+        ));
+        assert!(matches!(
+            ProverDbConsumerConfig::try_from_map(make_get(&[(
+                PROVER_DB_CONFIG_URL_KEY,
+                Some("http://example.com"),
+            )])),
+            Err(ProverDbConsumerConfigError::NotRegistered),
+        ));
+        assert!(matches!(
+            ProverDbConsumerConfig::try_from_map(make_get(&[
+                (PROVER_DB_CONFIG_URL_KEY, Some("http://example.com")),
+                (PROVER_DB_CONFIG_INCLUDE_KEY, None),
+            ])),
+            Err(ProverDbConsumerConfigError::NotRegistered),
+        ));
+        assert!(matches!(
+            ProverDbConsumerConfig::try_from_map(make_get(&[
+                (PROVER_DB_CONFIG_URL_KEY, Some("http://example.com")),
+                (PROVER_DB_CONFIG_INCLUDE_KEY, None),
+                (MAX_BLOCKS_PER_INVOCATION_CONFIG_KEY, None),
+            ])),
+            Err(ProverDbConsumerConfigError::NotRegistered),
+        ));
+    }
+
+    #[test]
+    fn try_from_map_fails_when_url_missing() {
+        assert!(matches!(
+            ProverDbConsumerConfig::try_from_map(make_get(&[(PROVER_DB_CONFIG_URL_KEY, None)])),
+            Err(ProverDbConsumerConfigError::MissingUrl),
+        ));
+    }
+
+    #[test]
+    fn try_from_map_fails_when_values_fail_to_parse() {
+        assert!(matches!(
+            ProverDbConsumerConfig::try_from_map(make_get(&[(
+                PROVER_DB_CONFIG_URL_KEY,
+                Some("not a url"),
+            )])),
+            Err(ProverDbConsumerConfigError::ParseUrl { .. }),
+        ));
+        assert!(matches!(
+            ProverDbConsumerConfig::try_from_map(make_get(&[
+                (PROVER_DB_CONFIG_URL_KEY, Some("http://example.com")),
+                (PROVER_DB_CONFIG_INCLUDE_KEY, Some("not-a-filter")),
+            ])),
+            Err(ProverDbConsumerConfigError::ParseFilter { .. }),
+        ));
+        assert!(matches!(
+            ProverDbConsumerConfig::try_from_map(make_get(&[
+                (PROVER_DB_CONFIG_URL_KEY, Some("http://example.com")),
+                (PROVER_DB_CONFIG_INCLUDE_KEY, None),
+                (MAX_BLOCKS_PER_INVOCATION_CONFIG_KEY, Some("not-a-number")),
+            ])),
+            Err(ProverDbConsumerConfigError::ParseMaxBlocks { .. }),
+        ));
+        assert!(matches!(
+            ProverDbConsumerConfig::try_from_map(make_get(&[
+                (PROVER_DB_CONFIG_URL_KEY, Some("http://example.com")),
+                (PROVER_DB_CONFIG_INCLUDE_KEY, None),
+                (MAX_BLOCKS_PER_INVOCATION_CONFIG_KEY, None),
+                (OCW_LOCK_DEADLINE_MS_CONFIG_KEY, Some("not-a-number")),
+            ])),
+            Err(ProverDbConsumerConfigError::ParseLockDeadline { .. }),
+        ));
+    }
+
+    #[test]
+    fn try_from_map_succeeds_with_provided_values() {
+        let config = ProverDbConsumerConfig::try_from_map(make_get(&[
+            (PROVER_DB_CONFIG_URL_KEY, Some("http://example.com")),
+            (PROVER_DB_CONFIG_INCLUDE_KEY, Some("ALPHA.T1,*.*")),
+            (MAX_BLOCKS_PER_INVOCATION_CONFIG_KEY, Some("42")),
+            (OCW_LOCK_DEADLINE_MS_CONFIG_KEY, Some("9999")),
+        ]))
+        .unwrap();
+        assert_eq!(config.url, Url::parse("http://example.com").unwrap());
+        assert_eq!(
+            config.include,
+            vec!["ALPHA.T1".parse().unwrap(), "*.*".parse().unwrap()],
+        );
+        assert_eq!(config.max_blocks_per_invocation, 42);
+        assert_eq!(config.ocw_lock_deadline_ms, 9999);
+    }
+
+    #[test]
+    fn try_from_map_succeeds_with_defaults_when_unset() {
+        let config = ProverDbConsumerConfig::try_from_map(make_get(&[
+            (PROVER_DB_CONFIG_URL_KEY, Some("http://example.com")),
+            (PROVER_DB_CONFIG_INCLUDE_KEY, None),
+            (MAX_BLOCKS_PER_INVOCATION_CONFIG_KEY, None),
+            (OCW_LOCK_DEADLINE_MS_CONFIG_KEY, None),
+        ]))
+        .unwrap();
+        assert_eq!(config.include, Vec::new());
+        assert_eq!(
+            config.max_blocks_per_invocation,
+            DEFAULT_MAX_BLOCKS_PER_INVOCATION,
+        );
+        assert_eq!(config.ocw_lock_deadline_ms, DEFAULT_OCW_LOCK_DEADLINE_MS);
+    }
+
+    #[test]
+    fn try_from_map_succeeds_with_empty_include() {
+        let config = ProverDbConsumerConfig::try_from_map(make_get(&[
+            (PROVER_DB_CONFIG_URL_KEY, Some("http://example.com")),
+            (PROVER_DB_CONFIG_INCLUDE_KEY, Some("")),
+            (MAX_BLOCKS_PER_INVOCATION_CONFIG_KEY, None),
+            (OCW_LOCK_DEADLINE_MS_CONFIG_KEY, None),
+        ]))
+        .unwrap();
+        assert_eq!(config.include, Vec::new());
     }
 
     // ── IdentFilter::matches ─────────────────────────────────────────


### PR DESCRIPTION
# Rationale for this change

#208 introduces generic key-value config for offchain workers. This PR uses it for the `prover_db_indexing` OCW.

# What changes are included in this PR?

* `ProverDbConsumerConfig` is populated from the new generic key-value config
* `max_blocks_per_invocation` and `ocw_lock_deadline_ms` are added to the configuration so they can be chosen by a node operator rather than hardcoded by the runtime. The default values keep the old values.

# Are these changes tested?

Yes