### PR TITLE
refactor: switch `db_events` to concrete `native_api::Api` instance

### DIFF
--- a/pallets/prover_db_indexer/Cargo.toml
+++ b/pallets/prover_db_indexer/Cargo.toml
@@ -23,6 +23,7 @@ polkadot-sdk = { workspace = true, features = [
 sxt-core.workspace = true
 commitment-sql.workspace = true
 native.workspace = true
+native-api = { workspace = true, default-features = false }
 pallet-indexing.workspace = true
 pallet-tables.workspace = true
 prost = { version = "0.13", default-features = false, features = ["prost-derive"] }
@@ -37,7 +38,6 @@ polkadot-sdk = { workspace = true, features = [
     "sp-staking", "frame-election-provider-support", "pallet-staking-reward-curve",
     "pallet-timestamp", "pallet-balances", "pallet-staking", "pallet-session",
 ]}
-native-api = { workspace = true, features = ["std"] }
 pallet-permissions.workspace = true
 pallet-commitments.workspace = true
 pallet-system-tables.workspace = true
@@ -54,6 +54,7 @@ std = [
     "sxt-core/std",
     "commitment-sql/std",
     "native/std",
+    "native-api/std",
     "pallet-indexing/std",
     "pallet-tables/std",
     "prost/std",

--- a/pallets/prover_db_indexer/src/db_events.rs
+++ b/pallets/prover_db_indexer/src/db_events.rs
@@ -3,8 +3,6 @@
 
 use alloc::string::String;
 use alloc::vec::Vec;
-use core::convert::Infallible;
-use core::marker::PhantomData;
 
 use codec::Decode;
 use pallet_tables::UpdateTableList;
@@ -45,7 +43,7 @@ type EventRecord<T> = frame_system::EventRecord<RuntimeEvent<T>, <T as frame_sys
 type Events<T: frame_system::Config> = StorageValue<frame_system::Pallet<T>, Vec<EventRecord<T>>>;
 
 /// A captured event from the node's client
-pub enum DBEvent<T: pallet_tables::Config + pallet_indexing::Config<I>, I: 'static = ()> {
+pub enum DBEvent<T: frame_system::Config> {
     /// Table definitions have been updated.
     SchemaUpdated(Option<T::AccountId>, UpdateTableList),
     /// A table has been successfully dropped.
@@ -58,17 +56,13 @@ pub enum DBEvent<T: pallet_tables::Config + pallet_indexing::Config<I>, I: 'stat
         /// The finalized raw data in postcard serialized OnChainTable bytes
         data: BoundedVec<u8, ConstU32<DATA_MAX_LEN>>,
     },
-    /// Never constructed; carries the `pallet_indexing` instance this `DBEvent` was decoded
-    /// against, since none of the variants above otherwise name it.
-    #[doc(hidden)]
-    _Instance(PhantomData<I>, Infallible),
 }
 
-impl<T, I> TryFrom<EventRecord<T>> for DBEvent<T, I>
+impl<T> TryFrom<EventRecord<T>> for DBEvent<T>
 where
-    T: pallet_tables::Config + pallet_indexing::Config<I>,
-    I: 'static,
-    RuntimeEvent<T>: TryInto<pallet_tables::Event<T>> + TryInto<pallet_indexing::Event<T, I>>,
+    T: pallet_tables::Config + pallet_indexing::Config<native_api::Api>,
+    RuntimeEvent<T>:
+        TryInto<pallet_tables::Event<T>> + TryInto<pallet_indexing::Event<T, native_api::Api>>,
 {
     type Error = ();
 
@@ -94,12 +88,10 @@ where
 }
 
 /// Queries the node's client for captured events at the given block hash.
-pub fn db_events_at<T, I: 'static>(
-    block_hash: H256,
-) -> Result<impl Iterator<Item = DBEvent<T, I>>, DBEventError>
+pub fn db_events_at<T>(block_hash: H256) -> Result<impl Iterator<Item = DBEvent<T>>, DBEventError>
 where
-    T: pallet_tables::Config + pallet_indexing::Config<I>,
-    EventRecord<T>: TryInto<DBEvent<T, I>>,
+    T: pallet_tables::Config + pallet_indexing::Config<native_api::Api>,
+    EventRecord<T>: TryInto<DBEvent<T>>,
 {
     let raw = native::client::client::storage(block_hash, Events::<T>::hashed_key().to_vec())
         .ok_or(DBEventError::NoClient)?
@@ -132,7 +124,7 @@ mod tests {
         let mut ext = new_test_ext();
         ext.execute_with(|| {
             assert!(matches!(
-                db_events_at::<Test, Api>(H256::zero()),
+                db_events_at::<Test>(H256::zero()),
                 Err(DBEventError::NoClient)
             ));
         });
@@ -146,7 +138,7 @@ mod tests {
             [Err("test error".to_string())],
         ));
         ext.execute_with(|| {
-            let err = db_events_at::<Test, Api>(H256::zero()).err().unwrap();
+            let err = db_events_at::<Test>(H256::zero()).err().unwrap();
             assert!(
                 matches!(err, DBEventError::Lookup { message } if message == "UnknownBlock: test error")
             );
@@ -159,7 +151,7 @@ mod tests {
         ext.register_extension(MockClientProvider::client_ext(None, [Ok(None)]));
         ext.execute_with(|| {
             assert!(matches!(
-                db_events_at::<Test, Api>(H256::zero()),
+                db_events_at::<Test>(H256::zero()),
                 Err(DBEventError::Empty)
             ));
         });
@@ -174,7 +166,7 @@ mod tests {
         ));
         ext.execute_with(|| {
             assert!(matches!(
-                db_events_at::<Test, Api>(H256::zero()),
+                db_events_at::<Test>(H256::zero()),
                 Err(DBEventError::Decode { .. })
             ));
         });
@@ -222,7 +214,7 @@ mod tests {
             [Ok(Some(StorageData(codec::Encode::encode(&records))))],
         ));
         ext.execute_with(|| {
-            let events: Vec<_> = db_events_at::<Test, Api>(H256::zero()).unwrap().collect();
+            let events: Vec<_> = db_events_at::<Test>(H256::zero()).unwrap().collect();
             assert_eq!(
                 events.len(),
                 3


### PR DESCRIPTION
# Rationale for this change

In order to simplify the code, we can use the `native_api::Api` in the `db_events` module directly. This is the concrete implementation that is used in the actual runtime, and it can also be used in tests. A generic type is not needed for mocking.

# Are these changes tested?

Existing test cover this change.